### PR TITLE
Collect various cleanup items

### DIFF
--- a/test/Allocate.tas
+++ b/test/Allocate.tas
@@ -28,7 +28,7 @@ _8Allocate02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -46,7 +46,7 @@ _8Allocate01_3b22array_allocate_boolean04_3b28295b1Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue:
      P  <- [O]
 
@@ -63,7 +63,7 @@ _8Allocate01_3b19array_allocate_char04_3b28295b1C:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue:
      P  <- [O]
 
@@ -80,7 +80,7 @@ _8Allocate01_3b20array_allocate_float04_3b28295b1F:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue:
      P  <- [O]
 
@@ -90,7 +90,7 @@ _8Allocate01_3b21array_allocate_double04_3b28295b1D:
      O  <-  O - 2
 .L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b3__0:
      B  <-  5
-     B  <-  B  +  B
+     B  <-  B + B
      O  <-  O - 1
      B  -> [O + 1]
     [O] <-  P + 1
@@ -98,7 +98,7 @@ _8Allocate01_3b21array_allocate_double04_3b28295b1D:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue:
      P  <- [O]
 
@@ -115,7 +115,7 @@ _8Allocate01_3b19array_allocate_byte04_3b28295b1B:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue:
      P  <- [O]
 
@@ -132,7 +132,7 @@ _8Allocate01_3b20array_allocate_short04_3b28295b1S:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue:
      P  <- [O]
 
@@ -149,7 +149,7 @@ _8Allocate01_3b18array_allocate_int04_3b28295b1I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue:
      P  <- [O]
 
@@ -159,7 +159,7 @@ _8Allocate01_3b19array_allocate_long04_3b28295b1J:
      O  <-  O - 2
 .L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b3__0:
      B  <-  5
-     B  <-  B  +  B
+     B  <-  B + B
      O  <-  O - 1
      B  -> [O + 1]
     [O] <-  P + 1
@@ -167,7 +167,7 @@ _8Allocate01_3b19array_allocate_long04_3b28295b1J:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue:
      P  <- [O]
 
@@ -188,7 +188,7 @@ _8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object01_3b
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 
@@ -205,7 +205,7 @@ _8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object01
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1)) + P
 .L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 

--- a/test/Compare.tas
+++ b/test/Compare.tas
@@ -36,7 +36,7 @@ _7Compare02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -57,15 +57,15 @@ _7Compare01_3b2lt02_3b282FF01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283FFI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B >=  A
-     P  <-  (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B >= A
+     P  <-  (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -86,15 +86,15 @@ _7Compare01_3b2le02_3b282FF01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283FFI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  A  <  B
-     P  <-  (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  A < B
+     P  <-  (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -115,15 +115,15 @@ _7Compare01_3b2eq02_3b282FF01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283FFI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__10 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__10 - (. + 1)) &~ B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -144,15 +144,15 @@ _7Compare01_3b2gt02_3b282FF01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283FFI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  A >=  B
-     P  <-  (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  A >= B
+     P  <-  (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -173,15 +173,15 @@ _7Compare01_3b2ge02_3b282FF01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283FFI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B  <  A
-     P  <-  (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B < A
+     P  <-  (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -202,15 +202,15 @@ _7Compare01_3b2ne02_3b282FF01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283FFI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B == A
+     P  <-  (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -235,15 +235,15 @@ _7Compare01_3b2lt02_3b282DD01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283DDI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B >=  A
-     P  <-  (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B >= A
+     P  <-  (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -268,15 +268,15 @@ _7Compare01_3b2le02_3b282DD01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283DDI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  A  <  B
-     P  <-  (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  A < B
+     P  <-  (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -301,15 +301,15 @@ _7Compare01_3b2eq02_3b282DD01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283DDI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__10 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__10 - (. + 1)) &~ B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -334,15 +334,15 @@ _7Compare01_3b2gt02_3b282DD01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283DDI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  A >=  B
-     P  <-  (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  A >= B
+     P  <-  (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -367,15 +367,15 @@ _7Compare01_3b2ge02_3b282DD01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283DDI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B  <  A
-     P  <-  (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B < A
+     P  <-  (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -400,15 +400,15 @@ _7Compare01_3b2ne02_3b282DD01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283DDI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B == A
+     P  <-  (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -433,15 +433,15 @@ _7Compare01_3b2lt02_3b282JJ01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283JJI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B >=  A
-     P  <-  (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B >= A
+     P  <-  (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -466,15 +466,15 @@ _7Compare01_3b2le02_3b282JJ01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283JJI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  A  <  B
-     P  <-  (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  A < B
+     P  <-  (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -499,15 +499,15 @@ _7Compare01_3b2eq02_3b282JJ01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283JJI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__10 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__10 - (. + 1)) &~ B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -532,15 +532,15 @@ _7Compare01_3b2gt02_3b282JJ01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283JJI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  A >=  B
-     P  <-  (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  A >= B
+     P  <-  (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -565,15 +565,15 @@ _7Compare01_3b2ge02_3b282JJ01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283JJI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B  <  A
-     P  <-  (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B < A
+     P  <-  (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -598,15 +598,15 @@ _7Compare01_3b2ne02_3b282JJ01_291Z:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3cmp02_3b283JJI01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__10 - (. + 1))  &  B + P
+     B  <-  B == A
+     P  <-  (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
      B  <-  1
      P  <-  P + (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__11 - (. + 1))
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]

--- a/test/Constant.tas
+++ b/test/Constant.tas
@@ -30,7 +30,7 @@ _8Constant02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -42,7 +42,7 @@ _8Constant01_3b12constant_int03_3b28291I:
 .L_8Constant01_3b12constant_int03_3b28291I01_3b3__0:
      B  <-  1
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue:
      P  <- [O]
 
@@ -55,7 +55,7 @@ _8Constant01_3b13constant_long03_3b28291J:
      C  <-  1
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -66,11 +66,11 @@ _8Constant01_3b14constant_float03_3b28291F:
      O  <-  O - 2
 .L_8Constant01_3b14constant_float03_3b28291F01_3b3__0:
      C  <-  260096
-     C  <-  C ^^  0
-     B  <-  A  |  A
-     B  <-  B  +  C
+     C  <-  C ^^ 0
+     B  <-  A | A
+     B  <-  B + C
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue:
      P  <- [O]
 
@@ -80,13 +80,13 @@ _8Constant01_3b15constant_double03_3b28291D:
      O  <-  O - 3
 .L_8Constant01_3b15constant_double03_3b28291D01_3b3__0:
      C  <-  261888
-     C  <-  C ^^  0
-     B  <-  A  |  A
-     B  <-  B  +  C
+     C  <-  C ^^ 0
+     B  <-  A | A
+     B  <-  B + C
      C  <-  0
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -98,7 +98,7 @@ _8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object01_3b:
 .L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b3__0:
      B  <-  0
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 
@@ -109,7 +109,7 @@ _8Constant01_3b9large_int03_3b28291I:
 .L_8Constant01_3b9large_int03_3b28291I01_3b3__0:
      B  <-  123456
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue:
      P  <- [O]
 
@@ -122,7 +122,7 @@ _8Constant01_3b10large_long03_3b28291J:
      C  <-  123456
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -133,11 +133,11 @@ _8Constant01_3b11large_float03_3b28291F:
      O  <-  O - 2
 .L_8Constant01_3b11large_float03_3b28291F01_3b3__0:
      C  <-  294674
-     C  <-  C ^^  0
-     B  <-  A  |  A
-     B  <-  B  +  C
+     C  <-  C ^^ 0
+     B  <-  A | A
+     B  <-  B + C
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue:
      P  <- [O]
 
@@ -147,13 +147,13 @@ _8Constant01_3b12large_double03_3b28291D:
      O  <-  O - 3
 .L_8Constant01_3b12large_double03_3b28291D01_3b3__0:
      C  <-  266210
-     C  <-  C ^^  1024
-     B  <-  A  |  A
-     B  <-  B  +  C
+     C  <-  C ^^ 1024
+     B  <-  A | A
+     B  <-  B + C
      C  <-  0
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue - (. + 1)) + P
 .L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]

--- a/test/Deep.tas
+++ b/test/Deep.tas
@@ -30,7 +30,7 @@ _4Deep02_3b3c4init04_3e3b28291V:
      D  <-  0
      D  -> [B + (@_4Deep01_3b3sum01_3b1J01_3b12field_offset + 1)]
      C  -> [B + (@_4Deep01_3b3sum01_3b1J01_3b12field_offset + 0)]
-     P  <-  (.L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -42,9 +42,9 @@ _4Deep01_3b3add02_3b282II01_291I:
 .L_4Deep01_3b3add02_3b282II01_291I01_3b3__0:
      B  <- [O + 3]
      C  <- [O + 2]
-     B  <-  B  +  C
+     B  <-  B + C
      B  -> [O + 3]
-     P  <-  (.L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -132,11 +132,11 @@ _4Deep01_3b7calling03_3b28291J:
      P  <-  P + @+_4Deep01_3b3add02_3b282II01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     C  <-  B  |  A
-     B  <-  C  @  31
+     C  <-  B | A
+     B  <-  C @ 31
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue - (. + 1)) + P
 .L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue:
      P  <- [O]
 

--- a/test/Empty.tas
+++ b/test/Empty.tas
@@ -19,7 +19,7 @@ _5Empty02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -29,7 +29,7 @@ _5Empty01_3b5empty03_3b28291V:
 .L_5Empty01_3b5empty03_3b28291V01_3b10__prologue:
      O  <-  O - 1
 .L_5Empty01_3b5empty03_3b28291V01_3b3__0:
-     P  <-  (.L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Except.tas
+++ b/test/Except.tas
@@ -23,7 +23,7 @@ _6Except02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -43,7 +43,7 @@ _6Except01_3b3sub02_3b281I01_291I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]
@@ -61,7 +61,7 @@ _6Except01_3b6except02_3b281I01_291I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 3]
-     P  <-  (.L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -81,7 +81,7 @@ _6Except01_3b6lastly02_3b281I01_291I:
      B  -> [O + 3]
      B  <-  -1
      B  -> [O + 4]
-     P  <-  (.L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 3
      P  <- [O - 2]
@@ -101,7 +101,7 @@ _6Except01_3b13except_lastly02_3b281I01_291I:
      B  -> [O + 4]
      B  <-  -1
      B  -> [O + 5]
-     P  <-  (.L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -121,7 +121,7 @@ _6Except01_3b14except2_lastly02_3b281I01_291I:
      B  -> [O + 4]
      B  <-  -1
      B  -> [O + 5]
-     P  <-  (.L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]

--- a/test/Expr.tas
+++ b/test/Expr.tas
@@ -19,7 +19,7 @@ _4Expr02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -31,21 +31,21 @@ _4Expr01_3b4expr02_3b282II01_291I:
 .L_4Expr01_3b4expr02_3b282II01_291I01_3b3__0:
      B  <- [O + 3]
      C  <- [O + 2]
-     B  <-  B  *  C
+     B  <-  B * C
      C  <- [O + 3]
      D  <- [O + 2]
-     C  <-  C  *  D
-     B  <-  B  -  C
+     C  <-  C * D
+     B  <-  B - C
      C  <-  4
-     B  <-  B  +  C
+     B  <-  B + C
      B  -> [O + 3]
      B  <- [O + 3]
      C  <- [O + 2]
-     B  <-  B  <  C
-     P  <-  (.L_4Expr01_3b4expr02_3b282II01_291I01_3b3__0 - (. + 1))  &  B + P
+     B  <-  B < C
+     P  <-  (.L_4Expr01_3b4expr02_3b282II01_291I01_3b3__0 - (. + 1)) & B + P
      B  <- [O + 3]
      B  -> [O + 3]
-     P  <-  (.L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Fields.tas
+++ b/test/Fields.tas
@@ -40,7 +40,7 @@ _6Fields02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -51,13 +51,13 @@ _6Fields01_3b13access_fields03_3b28291V:
      O  <-  O - 2
 .L_6Fields01_3b13access_fields03_3b28291V01_3b3__0:
      B  <- [O + 2]
-     C  <-  B  |  A
+     C  <-  B | A
      D  <- [C + (@_6Fields01_3b10numerosity01_3b1I01_3b12field_offset + 0)]
      D  <-  1
-     C  <-  C  +  D
+     C  <-  C + D
      C  -> [B + (@_6Fields01_3b10numerosity01_3b1I01_3b12field_offset + 0)]
      B  <- [O + 2]
-     C  <-  B  |  A
+     C  <-  B | A
      D  <- [C + (@_6Fields01_3b6length01_3b1J01_3b12field_offset + 0)]
      E  <- [C + (@_6Fields01_3b6length01_3b1J01_3b12field_offset + 1)]
      E  <-  0
@@ -79,8 +79,8 @@ _6Fields01_3b13access_fields03_3b28291V:
      B  <- [O + 2]
      C  <- [O + 2]
      D  <- [C + (@_6Fields01_3b10truthiness01_3b1Z01_3b12field_offset + 0)]
-     C  <-  C ==  A
-     P  <-  (.L_6Fields01_3b13access_fields03_3b28291V01_3b4__32 - (. + 1)) &~  C + P
+     C  <-  C == A
+     P  <-  (.L_6Fields01_3b13access_fields03_3b28291V01_3b4__32 - (. + 1)) &~ C + P
      C  <-  1
      P  <-  P + (.L_6Fields01_3b13access_fields03_3b28291V01_3b4__33 - (. + 1))
 .L_6Fields01_3b13access_fields03_3b28291V01_3b4__32:
@@ -90,11 +90,11 @@ _6Fields01_3b13access_fields03_3b28291V:
      C  <- [O + 2]
      D  <- [O + 2]
      E  <- [D + (@_6Fields01_3b14diminutiveness01_3b1S01_3b12field_offset + 0)]
-     D  <-  A  -  D
-     D  <-  D <<  16
-     D  <-  D >>  16
+     D  <-  A - D
+     D  <-  D << 16
+     D  <-  D >> 16
      D  -> [C + (@_6Fields01_3b14diminutiveness01_3b1S01_3b12field_offset + 0)]
-     P  <-  (.L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -106,7 +106,7 @@ _6Fields01_3b14access_statics03_3b28291V:
 .L_6Fields01_3b14access_statics03_3b28291V01_3b3__0:
      B  <- [P + ((@_6Fields01_3b17static_numerosity01_3b1I01_3b6static - (. + 1)) + 0)]
      C  <-  1
-     B  <-  B  +  C
+     B  <-  B + C
      B  -> [P + ((@_6Fields01_3b17static_numerosity01_3b1I01_3b6static - (. + 1)) + 0)]
      B  <- [P + ((@_6Fields01_3b13static_length01_3b1J01_3b6static - (. + 1)) + 0)]
      C  <- [P + ((@_6Fields01_3b13static_length01_3b1J01_3b6static - (. + 1)) + 1)]
@@ -126,8 +126,8 @@ _6Fields01_3b14access_statics03_3b28291V:
      O  <-  O + 1
      B  -> [P + ((@_6Fields01_3b13static_length01_3b1J01_3b6static - (. + 1)) + 0)]
      B  <- [P + ((@_6Fields01_3b17static_truthiness01_3b1Z01_3b6static - (. + 1)) + 0)]
-     B  <-  B ==  A
-     P  <-  (.L_6Fields01_3b14access_statics03_3b28291V01_3b4__26 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_6Fields01_3b14access_statics03_3b28291V01_3b4__26 - (. + 1)) &~ B + P
      B  <-  1
      P  <-  P + (.L_6Fields01_3b14access_statics03_3b28291V01_3b4__27 - (. + 1))
 .L_6Fields01_3b14access_statics03_3b28291V01_3b4__26:
@@ -135,11 +135,11 @@ _6Fields01_3b14access_statics03_3b28291V:
 .L_6Fields01_3b14access_statics03_3b28291V01_3b4__27:
      C  -> [P + ((@_6Fields01_3b17static_truthiness01_3b1Z01_3b6static - (. + 1)) + 0)]
      C  <- [P + ((@_6Fields01_3b21static_diminutiveness01_3b1S01_3b6static - (. + 1)) + 0)]
-     C  <-  A  -  C
-     C  <-  C <<  16
-     C  <-  C >>  16
+     C  <-  A - C
+     C  <-  C << 16
+     C  <-  C >> 16
      C  -> [P + ((@_6Fields01_3b21static_diminutiveness01_3b1S01_3b6static - (. + 1)) + 0)]
-     P  <-  (.L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/GCD.tas
+++ b/test/GCD.tas
@@ -19,7 +19,7 @@ _3GCD02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -31,27 +31,27 @@ _3GCD01_3b3gcd02_3b282II01_291I:
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b3__0:
      B  <- [O + 3]
      C  <- [O + 2]
-     B  <-  B ==  C
-     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__24 - (. + 1))  &  B + P
+     B  <-  B == C
+     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__24 - (. + 1)) & B + P
      B  <- [O + 3]
      C  <- [O + 2]
-     B  <-  C >=  B
-     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__17 - (. + 1))  &  B + P
+     B  <-  C >= B
+     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__17 - (. + 1)) & B + P
      B  <- [O + 3]
      C  <- [O + 2]
-     B  <-  B  -  C
+     B  <-  B - C
      B  -> [O + 3]
      P  <-  P + (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b3__0 - (. + 1))
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__17:
      B  <- [O + 2]
      C  <- [O + 3]
-     B  <-  B  -  C
+     B  <-  B - C
      B  -> [O + 2]
      P  <-  P + (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b3__0 - (. + 1))
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__24:
      B  <- [O + 3]
      B  -> [O + 3]
-     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Infinite.tas
+++ b/test/Infinite.tas
@@ -20,7 +20,7 @@ _8Infinite02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Loops.tas
+++ b/test/Loops.tas
@@ -19,7 +19,7 @@ _5Loops02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -36,47 +36,47 @@ _5Loops01_3b5deep503_3b28291I:
 .L_5Loops01_3b5deep503_3b28291I01_3b3__4:
      B  <- [O + 6]
      C  <-  3
-     B  <-  B >=  C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__85 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__85 - (. + 1)) & B + P
      B  <-  0
      B  -> [O + 5]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__11:
      B  <- [O + 5]
      C  <-  3
-     B  <-  B >=  C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__79 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__79 - (. + 1)) & B + P
      B  <-  0
      B  -> [O + 4]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__18:
      B  <- [O + 4]
      C  <-  3
-     B  <-  B >=  C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__73 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__73 - (. + 1)) & B + P
      B  <-  0
      B  -> [O + 3]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__26:
      B  <- [O + 3]
      C  <-  3
-     B  <-  B >=  C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__67 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__67 - (. + 1)) & B + P
      B  <-  0
      B  -> [O + 2]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__35:
      B  <- [O + 2]
      C  <-  3
-     B  <-  B >=  C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__61 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__61 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <- [O + 6]
      D  <- [O + 5]
-     C  <-  C  +  D
+     C  <-  C + D
      D  <- [O + 4]
-     C  <-  C  +  D
+     C  <-  C + D
      D  <- [O + 3]
-     C  <-  C  +  D
+     C  <-  C + D
      D  <- [O + 2]
-     C  <-  C  +  D
-     B  <-  B  +  C
+     C  <-  C + D
+     B  <-  B + C
      B  -> [O + 7]
      B  <- [O + 2]
      B  <-  B + 1
@@ -105,7 +105,7 @@ _5Loops01_3b5deep503_3b28291I:
 .L_5Loops01_3b5deep503_3b28291I01_3b4__85:
      B  <- [O + 7]
      B  -> [O + 7]
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue - (. + 1)) + P
 .L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue:
      O  <-  O + 6
      P  <- [O - 5]

--- a/test/Native.tas
+++ b/test/Native.tas
@@ -20,7 +20,7 @@ _6Native02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,7 +32,7 @@ _6Native01_3b6caller03_3b28291V:
 .L_6Native01_3b6caller03_3b28291V01_3b3__0:
     [O] <-  P + 1
      P  <-  P + @+_6Native01_3b10nativeCall03_3b28291V
-     P  <-  (.L_6Native01_3b6caller03_3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Native01_3b6caller03_3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Native01_3b6caller03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Nest.tas
+++ b/test/Nest.tas
@@ -19,7 +19,7 @@ _4Nest02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -36,43 +36,43 @@ _4Nest01_3b4nest02_3b282II01_291I:
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b3__4:
      B  <- [O + 5]
      C  <- [O + 3]
-     B  <-  B >=  C
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__56 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__56 - (. + 1)) & B + P
      B  <- [O + 6]
      C  <- [O + 3]
-     B  <-  B  +  C
+     B  <-  B + C
      B  -> [O + 6]
      B  <- [O + 5]
      C  <- [O + 6]
-     B  <-  B  -  C
+     B  <-  B - C
      B  -> [O + 5]
      B  <-  0
      B  -> [O + 2]
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b4__20:
      B  <- [O + 2]
      C  <- [O + 5]
-     B  <-  B >=  C
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__53 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__53 - (. + 1)) & B + P
      B  <- [O + 6]
      C  <- [O + 5]
-     B  <-  B  +  C
+     B  <-  B + C
      B  -> [O + 6]
      B  <- [O + 3]
      C  <- [O + 6]
-     B  <-  B  -  C
+     B  <-  B - C
      B  -> [O + 3]
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b4__34:
      B  <- [O + 3]
      C  <- [O + 2]
-     B  <-  B  *  C
+     B  <-  B * C
      B  -> [O + 6]
      B  <- [O + 5]
      B  <-  B - 1
      B  -> [O + 5]
      B  <- [O + 6]
      C  <- [O + 5]
-     B  <-  B  <  C
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__34 - (. + 1))  &  B + P
+     B  <-  B < C
+     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__34 - (. + 1)) & B + P
      B  <- [O + 2]
      B  <-  B + 1
      B  -> [O + 2]
@@ -82,7 +82,7 @@ _4Nest01_3b4nest02_3b282II01_291I:
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b4__56:
      B  <- [O + 4]
      B  -> [O + 6]
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 5
      P  <- [O - 4]

--- a/test/Recurse.tas
+++ b/test/Recurse.tas
@@ -21,7 +21,7 @@ _7Recurse02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -37,7 +37,7 @@ _7Recurse01_3b7recurse03_3b28291V:
      B  <- [B - 1]
     [O] <-  P + 1
      P  <- [B + @_7Recurse01_3b7recurse03_3b28291V01_3b5vslot]
-     P  <-  (.L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Sieve.tas
+++ b/test/Sieve.tas
@@ -40,7 +40,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 7]
      C  <-  0
      D  <-  2
-     D  -> [C  |  0 + B]
+     D  -> [C + B]
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__11:
      B  <- [O + 6]
      C  <-  1
@@ -49,7 +49,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 7]
      C  <-  1
      D  <-  3
-     D  -> [C  |  0 + B]
+     D  -> [C + B]
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__20:
      B  <-  2
      B  -> [O + 5]
@@ -62,7 +62,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      C  <- [O + 5]
      D  <-  1
      C  <-  C  -  D
-     B  <- [C  |  0 + B]
+     B  <- [C + B]
      C  <-  2
      B  <-  B  +  C
      B  -> [O + 4]
@@ -81,10 +81,10 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1))  &  B + P
      B  <- [O + 7]
      C  <- [O + 2]
-     B  <- [C  |  0 + B]
+     B  <- [C + B]
      C  <- [O + 7]
      D  <- [O + 2]
-     C  <- [D  |  0 + C]
+     C  <- [D + C]
      B  <-  B  *  C
      C  <- [O + 4]
      B  <-  C  <  B
@@ -92,7 +92,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 4]
      C  <- [O + 7]
      D  <- [O + 2]
-     C  <- [D  |  0 + C]
+     C  <- [D + C]
      O  <-  O - 2
      B  -> [O + 2]
      C  -> [O + 1]
@@ -116,7 +116,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 7]
      C  <- [O + 5]
      D  <- [O + 4]
-     D  -> [C  |  0 + B]
+     D  -> [C + B]
      P  <-  P + (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__105 - (. + 1))
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__99:
      B  <- [O + 4]

--- a/test/Sieve.tas
+++ b/test/Sieve.tas
@@ -21,7 +21,7 @@ _5Sieve02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -35,8 +35,8 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [B - 1]
      B  -> [O + 6]
      B  <- [O + 6]
-     B  <-  A >=  B
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__11 - (. + 1))  &  B + P
+     B  <-  A >= B
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__11 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <-  0
      D  <-  2
@@ -44,8 +44,8 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__11:
      B  <- [O + 6]
      C  <-  1
-     B  <-  C >=  B
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__20 - (. + 1))  &  B + P
+     B  <-  C >= B
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__20 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <-  1
      D  <-  3
@@ -56,15 +56,15 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__22:
      B  <- [O + 5]
      C  <- [O + 6]
-     B  <-  B >=  C
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__111 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__111 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <-  1
-     C  <-  C  -  D
+     C  <-  C - D
      B  <- [C + B]
      C  <-  2
-     B  <-  B  +  C
+     B  <-  B + C
      B  -> [O + 4]
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__36:
      B  <-  0
@@ -73,22 +73,22 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 2]
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__42:
      B  <- [O + 3]
-     B  <-  B ==  A
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) &~ B + P
      B  <- [O + 2]
      C  <- [O + 5]
-     B  <-  B >=  C
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <- [O + 2]
      B  <- [C + B]
      C  <- [O + 7]
      D  <- [O + 2]
      C  <- [D + C]
-     B  <-  B  *  C
+     B  <-  B * C
      C  <- [O + 4]
-     B  <-  C  <  B
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1))  &  B + P
+     B  <-  C < B
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
      B  <- [O + 4]
      C  <- [O + 7]
      D  <- [O + 2]
@@ -100,8 +100,8 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3rem02_3b282II01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__80 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__80 - (. + 1)) &~ B + P
      B  <-  1
      B  -> [O + 3]
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__80:
@@ -111,8 +111,8 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      P  <-  P + (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__42 - (. + 1))
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86:
      B  <- [O + 3]
-     B  <-  B ==  A
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__99 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__99 - (. + 1)) &~ B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <- [O + 4]
@@ -129,7 +129,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 5]
      P  <-  P + (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__22 - (. + 1))
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__111:
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue - (. + 1)) + P
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue:
      O  <-  O + 8
      P  <- [O - 7]

--- a/test/Static.tas
+++ b/test/Static.tas
@@ -22,7 +22,7 @@ _6Static02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -34,7 +34,7 @@ _6Static02_3b3c6clinit04_3e3b28291V:
 .L_6Static02_3b3c6clinit04_3e3b28291V01_3b3__0:
      B  <-  3
      B  -> [P + ((@_6Static01_3b1a01_3b1I01_3b6static - (. + 1)) + 0)]
-     P  <-  (.L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Switch.tas
+++ b/test/Switch.tas
@@ -20,7 +20,7 @@ _6Switch02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -31,32 +31,32 @@ _6Switch01_3b5table02_3b282II01_291I:
      O  <-  O - 1
 .L_6Switch01_3b5table02_3b282II01_291I01_3b3__0:
      B  <- [O + 3]
-     C  <-  B  <  1
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 - (. + 1))  &  C + P
-     C  <-  3  <  B
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 - (. + 1))  &  C + P
-     P  <-  B  -  1 + P
+     C  <-  B < 1
+     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 - (. + 1)) & C + P
+     C  <-  3 < B
+     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 - (. + 1)) & C + P
+     P  <-  B - 1 + P
      P  <-  P + (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__28 - (. + 1))
      P  <-  P + (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__30 - (. + 1))
      P  <-  P + (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__34 - (. + 1))
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__28:
      C  <- [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__30:
      C  <- [O + 3]
      D  <- [O + 2]
-     C  <-  C  *  D
+     C  <-  C * D
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__34:
      C  <- [O + 3]
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__36:
      C  <-  0
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -67,36 +67,36 @@ _6Switch01_3b6lookup02_3b282II01_291I:
      O  <-  O - 1
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b3__0:
      B  <- [O + 3]
-     C  <-  B ==  1
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__36 - (. + 1))  &  C + P
+     C  <-  B == 1
+     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__36 - (. + 1)) & C + P
      D  <-  8483
-     C  <-  B ==  D
-     C  <-  C  +  A
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__38 - (. + 1))  &  C + P
+     C  <-  B == D
+     C  <-  C + A
+     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__38 - (. + 1)) & C + P
      D  <-  530
-     D  <-  D ^^  837
-     C  <-  B ==  D
-     C  <-  C  +  A
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__42 - (. + 1))  &  C + P
+     D  <-  D ^^ 837
+     C  <-  B == D
+     C  <-  C + A
+     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__42 - (. + 1)) & C + P
      P  <-  P + (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__44 - (. + 1))
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__36:
      D  <- [O + 2]
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__38:
      D  <- [O + 3]
      E  <- [O + 2]
-     D  <-  D  *  E
+     D  <-  D * E
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__42:
      D  <- [O + 3]
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__44:
      D  <-  0
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Tiny.tas
+++ b/test/Tiny.tas
@@ -21,7 +21,7 @@ _4Tiny02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -35,8 +35,8 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [B - 1]
      B  -> [O + 6]
      B  <- [O + 6]
-     B  <-  A >=  B
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__11 - (. + 1))  &  B + P
+     B  <-  A >= B
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__11 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <-  0
      D  <-  2
@@ -44,8 +44,8 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__11:
      B  <- [O + 6]
      C  <-  1
-     B  <-  C >=  B
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__20 - (. + 1))  &  B + P
+     B  <-  C >= B
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__20 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <-  1
      D  <-  3
@@ -56,15 +56,15 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__22:
      B  <- [O + 5]
      C  <- [O + 6]
-     B  <-  B >=  C
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__111 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__111 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <-  1
-     C  <-  C  -  D
+     C  <-  C - D
      B  <- [C + B]
      C  <-  2
-     B  <-  B  +  C
+     B  <-  B + C
      B  -> [O + 4]
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__36:
      B  <-  0
@@ -73,22 +73,22 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 2]
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__42:
      B  <- [O + 3]
-     B  <-  B ==  A
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) &~ B + P
      B  <- [O + 2]
      C  <- [O + 5]
-     B  <-  B >=  C
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1))  &  B + P
+     B  <-  B >= C
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
      B  <- [O + 7]
      C  <- [O + 2]
      B  <- [C + B]
      C  <- [O + 7]
      D  <- [O + 2]
      C  <- [D + C]
-     B  <-  B  *  C
+     B  <-  B * C
      C  <- [O + 4]
-     B  <-  C  <  B
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1))  &  B + P
+     B  <-  C < B
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
      B  <- [O + 4]
      C  <- [O + 7]
      D  <- [O + 2]
@@ -100,8 +100,8 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3rem02_3b282II01_291I
      B  <- [O + 1]
      O  <-  O + 1
-     B  <-  B ==  A
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__80 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__80 - (. + 1)) &~ B + P
      B  <-  1
      B  -> [O + 3]
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__80:
@@ -111,8 +111,8 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      P  <-  P + (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__42 - (. + 1))
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86:
      B  <- [O + 3]
-     B  <-  B ==  A
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__99 - (. + 1)) &~  B + P
+     B  <-  B == A
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__99 - (. + 1)) &~ B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <- [O + 4]
@@ -129,7 +129,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 5]
      P  <-  P + (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__22 - (. + 1))
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__111:
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue - (. + 1)) + P
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue:
      O  <-  O + 8
      P  <- [O - 7]

--- a/test/Tiny.tas
+++ b/test/Tiny.tas
@@ -40,7 +40,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 7]
      C  <-  0
      D  <-  2
-     D  -> [C  |  0 + B]
+     D  -> [C + B]
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__11:
      B  <- [O + 6]
      C  <-  1
@@ -49,7 +49,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 7]
      C  <-  1
      D  <-  3
-     D  -> [C  |  0 + B]
+     D  -> [C + B]
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__20:
      B  <-  2
      B  -> [O + 5]
@@ -62,7 +62,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      C  <- [O + 5]
      D  <-  1
      C  <-  C  -  D
-     B  <- [C  |  0 + B]
+     B  <- [C + B]
      C  <-  2
      B  <-  B  +  C
      B  -> [O + 4]
@@ -81,10 +81,10 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1))  &  B + P
      B  <- [O + 7]
      C  <- [O + 2]
-     B  <- [C  |  0 + B]
+     B  <- [C + B]
      C  <- [O + 7]
      D  <- [O + 2]
-     C  <- [D  |  0 + C]
+     C  <- [D + C]
      B  <-  B  *  C
      C  <- [O + 4]
      B  <-  C  <  B
@@ -92,7 +92,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 4]
      C  <- [O + 7]
      D  <- [O + 2]
-     C  <- [D  |  0 + C]
+     C  <- [D + C]
      O  <-  O - 2
      B  -> [O + 2]
      C  -> [O + 1]
@@ -116,7 +116,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 7]
      C  <- [O + 5]
      D  <- [O + 4]
-     D  -> [C  |  0 + B]
+     D  -> [C + B]
      P  <-  P + (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__105 - (. + 1))
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__99:
      B  <- [O + 4]

--- a/test/Varargs.tas
+++ b/test/Varargs.tas
@@ -19,7 +19,7 @@ _7Varargs02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,7 +32,7 @@ _7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I:
      B  <- [O + 2]
      B  <- [B - 1]
      B  -> [O + 2]
-     P  <-  (.L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue - (. + 1)) + P
 .L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/interesting/module/name/Packaged.tas
+++ b/test/interesting/module/name/Packaged.tas
@@ -24,7 +24,7 @@ _11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -35,12 +35,12 @@ _11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V:
      O  <-  O - 2
 .L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b3__0:
      B  <- [O + 2]
-     C  <-  B  |  A
+     C  <-  B | A
      D  <- [C + (@_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b5field01_3b1I01_3b12field_offset + 0)]
      D  <-  1
-     C  <-  C  +  D
+     C  <-  C + D
      C  -> [B + (@_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b5field01_3b1I01_3b12field_offset + 0)]
-     P  <-  (.L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue - (. + 1))  +  P
+     P  <-  (.L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue - (. + 1)) + P
 .L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/tyrga-lib/src/exprtree.rs
+++ b/tyrga-lib/src/exprtree.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -18,7 +19,7 @@ impl fmt::Display for Operation {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Atom {
-    Variable(String),
+    Variable(Cow<'static, str>),
     Immediate(i32),
     Expression(Box<Expr>),
 }
@@ -32,6 +33,18 @@ impl fmt::Display for Atom {
             Expression(e) => write!(f, "{e}"),
         }
     }
+}
+
+impl From<&'static str> for Atom {
+    fn from(s : &'static str) -> Self { Atom::Variable(Cow::from(s)) }
+}
+
+impl From<String> for Atom {
+    fn from(s : String) -> Self { Atom::Variable(Cow::from(s)) }
+}
+
+impl From<Expr> for Atom {
+    fn from(e : Expr) -> Self { Atom::Expression(Box::new(e)) }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -54,7 +67,7 @@ fn test_expr_display() {
     use Operation::*;
 
     let e = Expr {
-        a :  Variable("A".to_string()),
+        a :  Variable("A".into()),
         op : Add,
         b :  Immediate(3),
     };
@@ -62,7 +75,7 @@ fn test_expr_display() {
     let f = Expr {
         a :  Expression(e.clone()),
         op : Sub,
-        b :  Variable("B".to_string()),
+        b :  Variable("B".into()),
     };
     let f = Box::new(f);
     let g = Expr {

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -226,17 +226,22 @@ fn test_expand() -> GeneralResult<()> {
 type InsnPair = (Vec<Instruction>, Vec<Destination>);
 
 fn make_target(target : impl std::string::ToString) -> exprtree::Atom {
-    use exprtree::Atom::*;
+    use exprtree::Atom::Immediate;
     use exprtree::Expr;
     use exprtree::Operation::{Add, Sub};
 
-    let a = Variable(target.to_string().into());
-    let b = Expression(Box::new(Expr {
-        a :  Variable(".".to_owned().into()),
+    let b = Expr {
+        a :  ".".into(),
         op : Add,
         b :  Immediate(1),
-    }));
-    Expression(Box::new(Expr { a, op : Sub, b }))
+    }
+    .into();
+    Expr {
+        a : target.to_string().into(),
+        op : Sub,
+        b,
+    }
+    .into()
 }
 
 fn make_int_branch(
@@ -1092,7 +1097,7 @@ fn make_varaction<'a>(
             let b = Atom::Immediate(i);
             let op = exprtree::Operation::Add;
             let e = exprtree::Expr { a, b, op };
-            tenyr::Immediate20::Expr(Atom::Expression(Box::new(e)))
+            tenyr::Immediate20::Expr(e.into())
         };
 
         let op_depth = match op {

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -753,7 +753,7 @@ fn make_switch(
 
 fn make_array_op(sm : &mut StackManager, op : ArrayOperation) -> Vec<Instruction> {
     use jvmtypes::ArrayOperation::{GetLength, Load, Store};
-    use tenyr::InstructionType::{Type1, Type3};
+    use tenyr::InstructionType::*;
     use tenyr::MemoryOpType::{LoadRight, StoreRight};
     use tenyr::{InsnGeneral, Opcode};
 
@@ -800,13 +800,13 @@ fn make_array_op(sm : &mut StackManager, op : ArrayOperation) -> Vec<Instruction
     };
     // For now, all arrays of int or smaller are stored unpacked (i.e. one bool/short/char
     // per 32-bit tenyr word)
-    let (op, imm) = match kind.size() {
-        1 => (Opcode::BitwiseOr, 0_u8),
-        2 => (Opcode::ShiftLeft, 1_u8),
+    let (ctor, op, imm) : (fn(_) -> _, _, _) = match kind.size() {
+        1 => (Type2, Opcode::BitwiseOr, 0_u8),
+        2 => (Type1, Opcode::ShiftLeft, 1_u8),
         _ => unreachable!(), // impossible size
     };
     let imm = imm.into();
-    let kind = Type1(InsnGeneral { y, op, imm });
+    let kind = ctor(InsnGeneral { y, op, imm });
     let insn = Instruction { kind, z, x, dd };
     v.push(insn);
     v

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -1154,10 +1154,10 @@ fn make_instructions<'a>(
     // follow multiple destinations. Each basic block needs to be visited only once, however, since
     // the JVM guarantees that every instance of every instruction within a method always sees the
     // same depth of the operand stack every time that instance is executed.
-    let branching = |x| x;
-    let no_branch = |x| Ok((x, vec![Destination::Successor]));
+    let branching = GeneralResult::Ok;
+    let no_branch = |x| GeneralResult::Ok((x, vec![Destination::Successor]));
 
-    let make_jump = |_sm, target| Ok(make_jump(target, &namer(&target)?));
+    let make_jump = |_sm, target| GeneralResult::Ok(make_jump(target, &namer(&target)?));
     let make_noop = |_sm| vec![tenyr::NOOP_TYPE0];
     let make_branch = |sm, ops, way, target| make_branch(sm, ops, way, target, &namer(&target)?);
     let make_yield  = |sm, kind| make_yield(sm, kind, &namer(&"epilogue")?, max_locals);
@@ -1166,19 +1166,19 @@ fn make_instructions<'a>(
         Allocation { 0 : details      } => no_branch( make_allocation ( sm, details, gc              )?),
         Arithmetic { kind, op         } => no_branch( make_arithmetic ( sm, kind, op                 )?),
         ArrayOp    { 0 : aop          } => no_branch( make_array_op   ( sm, aop                      ) ),
-        Branch     { ops, way, target } => branching( make_branch     ( sm, ops, way, target         ) ),
+        Branch     { ops, way, target } => branching( make_branch     ( sm, ops, way, target         )?),
         Compare    { kind, nans       } => no_branch( make_compare    ( sm, kind, nans               )?),
         Constant   { 0 : details      } => no_branch( make_constant   ( sm, gc, details              )?),
         Conversion { from, to         } => no_branch( make_conversion ( sm, from, to                 )?),
         Increment  { index, value     } => no_branch( make_increment  ( sm, index, value, max_locals )?),
         Invocation { kind, index      } => no_branch( make_invocation ( sm, kind, index, gc          )?),
-        Jump       { target           } => branching( make_jump       ( sm, target                   ) ),
+        Jump       { target           } => branching( make_jump       ( sm, target                   )?),
         LocalOp    { 0 : op           } => no_branch( make_mem_op     ( sm, op, max_locals           ) ),
         Noop       {                  } => no_branch( make_noop       ( sm                           ) ),
         StackOp    { op, size         } => no_branch( make_stack_op   ( sm, op, size                 ) ),
-        Switch     { 0 : params       } => branching( make_switch     ( sm, params, namer, addr      ) ),
+        Switch     { 0 : params       } => branching( make_switch     ( sm, params, namer, addr      )?),
         VarAction  { op, kind, index  } => no_branch( make_varaction  ( sm, op, kind, index, gc      )?),
-        Yield      { kind             } => branching( make_yield      ( sm, kind                     ) ),
+        Yield      { kind             } => branching( make_yield      ( sm, kind                     )?),
 
         Unhandled  { ..               } => unimplemented!("unhandled operation {:?}", op)
     }

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -230,9 +230,9 @@ fn make_target(target : impl std::string::ToString) -> exprtree::Atom {
     use exprtree::Expr;
     use exprtree::Operation::{Add, Sub};
 
-    let a = Variable(target.to_string());
+    let a = Variable(target.to_string().into());
     let b = Expression(Box::new(Expr {
-        a :  Variable(".".to_owned()),
+        a :  Variable(".".to_owned().into()),
         op : Add,
         b :  Immediate(1),
     }));
@@ -295,7 +295,7 @@ fn make_call(
     // decrement stack pointer)
     let sp = sm.get_stack_ptr();
     let far = format!("@+{target}");
-    let off = tenyr::Immediate20::Expr(exprtree::Atom::Variable(far));
+    let off = tenyr::Immediate20::Expr(exprtree::Atom::Variable(far.into()));
     insns.extend(tenyr_insn_list!(
         [sp] <- P + 1   ;
         P <- P + (off)  ;
@@ -834,7 +834,7 @@ fn make_invocation_virtual(
     let (temp, gets) = sm.reserve_one();
     insns.extend(gets);
     let far = format!("@{}", mangle(&[&method_name, &"vslot"]));
-    let off = Immediate20::Expr(exprtree::Atom::Variable(far));
+    let off = Immediate20::Expr(exprtree::Atom::Variable(far.into()));
 
     insns.extend(tenyr_insn_list!(
         temp <- [obj - 1]   ;
@@ -1104,7 +1104,11 @@ fn make_varaction<'a>(
 
         let (drops, (reg, mut insns), base) = match kind {
             VarKind::Static => (0, (Register::P, vec![]), make_target(format("static"))),
-            VarKind::Field => (1, sm.get(op_depth), Atom::Variable(format("field_offset"))),
+            VarKind::Field => (
+                1,
+                sm.get(op_depth),
+                Atom::Variable(format("field_offset").into()),
+            ),
         };
 
         let mut range = 0_i32..len.into();

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -1,5 +1,3 @@
-#![allow(unused_macros)]
-
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
@@ -213,7 +211,6 @@ macro_rules! tenyr_insn {
 
 #[rustfmt::skip]
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn test_macro_insn() -> Result<(), Box<dyn std::error::Error>> {
     use InstructionType::*;
     use MemoryOpType::*;

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -415,11 +415,7 @@ impl fmt::Display for Opcode {
             CompareEq       => "==", TestBit          => "@"  ,
             CompareLt       => "<" , CompareGe        => ">=" ,
         };
-        // Support a tiny, inconsistent subset of formatting commands
-        match f.align() {
-            Some(fmt::Alignment::Center) => write!(f, "{:^3}", s),
-            _ => write!(f, "{s}"),
-        }
+        write!(f, "{s}")
     }
 }
 

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -401,9 +401,9 @@ pub enum Opcode {
 }
 
 impl fmt::Display for Opcode {
-    #[rustfmt::skip]
     fn fmt(&self, f : &mut fmt::Formatter) -> fmt::Result {
         use Opcode::*;
+        #[rustfmt::skip]
         let s = match self {
             BitwiseOr       => "|" , BitwiseOrn       => "|~" ,
             BitwiseAnd      => "&" , BitwiseAndn      => "&~" ,

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -654,15 +654,15 @@ impl fmt::Display for Instruction {
             Type2(Gen { op : Opcode::BitwiseOr, imm : Immediate::Fixed(imm), .. }) if imm == 0_u8.into()
                 => format!("{b} + {c}"),
             Type0(Gen { op, imm : Immediate::Fixed(imm), .. }) if imm == 0_u8.into()
-                => format!("{a} {op:^3} {b}"),
+                => format!("{a} {op} {b}"),
             Type1(Gen { op, y: Register::A, .. }) | Type2(Gen { op, y: Register::A, .. })
-                => format!("{a} {op:^3} {b}"),
+                => format!("{a} {op} {b}"),
             Type0(Gen { op, imm : Immediate::Fixed(imm), .. }) if i32::from(imm) < 0
-                => format!("{a} {op:^3} {b} - {imm}", imm=(-i32::from(imm))),
+                => format!("{a} {op} {b} - {imm}", imm=(-i32::from(imm))),
             Type0(Gen { op, .. }) |
             Type1(Gen { op, .. }) |
             Type2(Gen { op, .. })
-                => format!("{a} {op:^3} {b} + {c}"),
+                => format!("{a} {op} {b} + {c}"),
         };
 
         {
@@ -699,22 +699,22 @@ fn instruction_test_cases() -> Vec<(&'static str, Instruction)> {
     let neg4_20 = Immediate20::from(-4_i8);
 
     vec![
-        (" B  <-  C  |  D - 3"  , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : neg3_12.clone(), y : D, op : BitwiseOr       }) }),
-        (" B  <-  C |~  D"      , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : zero_12.clone(), y : D, op : BitwiseOrn      }) }),
-        (" B  <-  C  &  -3 + D" , Insn { dd : NoLoad    , z : B, x : C, kind : Type1(Gen { imm : neg3_12.clone(), y : D, op : BitwiseAnd      }) }),
-        (" B  <-  C &~  0 + D"  , Insn { dd : NoLoad    , z : B, x : C, kind : Type1(Gen { imm : zero_12.clone(), y : D, op : BitwiseAndn     }) }),
-        (" B  <-  -3  ^  C + D" , Insn { dd : NoLoad    , z : B, x : C, kind : Type2(Gen { imm : neg3_12.clone(), y : D, op : BitwiseXor      }) }),
-        (" B  <-  0 ^^  C + D"  , Insn { dd : NoLoad    , z : B, x : C, kind : Type2(Gen { imm : zero_12.clone(), y : D, op : Pack            }) }),
-        (" B  <-  C >>  D - 3"  , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : neg3_12.clone(), y : D, op : ShiftRightArith }) }),
-        (" B  <-  C >>> D"      , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : zero_12.clone(), y : D, op : ShiftRightLogic }) }),
-        (" B  <-  C ==  A - 3"  , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : neg3_12.clone(), y : A, op : CompareEq       }) }),
-        (" B  <-  C  @  A"      , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : zero_12.clone(), y : A, op : TestBit         }) }),
-        (" P  <-  C - 4"        , Insn { dd : NoLoad    , z : P, x : C, kind : Type3(neg4_20.clone()) }),
-        (" P  <-  C"            , Insn { dd : NoLoad    , z : P, x : C, kind : Type3(zero_20.clone()) }),
-        (" P  -> [C]"           , Insn { dd : StoreRight, z : P, x : C, kind : Type3(zero_20.clone()) }),
-        (" P  <- [C]"           , Insn { dd : LoadRight , z : P, x : C, kind : Type3(zero_20.clone()) }),
-        ("[P] <-  C"            , Insn { dd : StoreLeft , z : P, x : C, kind : Type3(zero_20.clone()) }),
-        (" P  <-  0"            , Insn { dd : NoLoad    , z : P, x : A, kind : Type3(zero_20.clone()) }),
+        (" B  <-  C | D - 3"  , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : neg3_12.clone(), y : D, op : BitwiseOr       }) }),
+        (" B  <-  C |~ D"     , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : zero_12.clone(), y : D, op : BitwiseOrn      }) }),
+        (" B  <-  C & -3 + D" , Insn { dd : NoLoad    , z : B, x : C, kind : Type1(Gen { imm : neg3_12.clone(), y : D, op : BitwiseAnd      }) }),
+        (" B  <-  C &~ 0 + D" , Insn { dd : NoLoad    , z : B, x : C, kind : Type1(Gen { imm : zero_12.clone(), y : D, op : BitwiseAndn     }) }),
+        (" B  <-  -3 ^ C + D" , Insn { dd : NoLoad    , z : B, x : C, kind : Type2(Gen { imm : neg3_12.clone(), y : D, op : BitwiseXor      }) }),
+        (" B  <-  0 ^^ C + D" , Insn { dd : NoLoad    , z : B, x : C, kind : Type2(Gen { imm : zero_12.clone(), y : D, op : Pack            }) }),
+        (" B  <-  C >> D - 3" , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : neg3_12.clone(), y : D, op : ShiftRightArith }) }),
+        (" B  <-  C >>> D"    , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : zero_12.clone(), y : D, op : ShiftRightLogic }) }),
+        (" B  <-  C == A - 3" , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : neg3_12.clone(), y : A, op : CompareEq       }) }),
+        (" B  <-  C @ A"      , Insn { dd : NoLoad    , z : B, x : C, kind : Type0(Gen { imm : zero_12.clone(), y : A, op : TestBit         }) }),
+        (" P  <-  C - 4"      , Insn { dd : NoLoad    , z : P, x : C, kind : Type3(neg4_20.clone()) }),
+        (" P  <-  C"          , Insn { dd : NoLoad    , z : P, x : C, kind : Type3(zero_20.clone()) }),
+        (" P  -> [C]"         , Insn { dd : StoreRight, z : P, x : C, kind : Type3(zero_20.clone()) }),
+        (" P  <- [C]"         , Insn { dd : LoadRight , z : P, x : C, kind : Type3(zero_20.clone()) }),
+        ("[P] <-  C"          , Insn { dd : StoreLeft , z : P, x : C, kind : Type3(zero_20.clone()) }),
+        (" P  <-  0"          , Insn { dd : NoLoad    , z : P, x : A, kind : Type3(zero_20.clone()) }),
     ]
 }
 

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -651,6 +651,8 @@ impl fmt::Display for Instruction {
                 => format!("{a} - {c}", c=(-i32::from(imm))),
             Type3(..)
                 => format!("{a} + {c}"),
+            Type2(Gen { op : Opcode::BitwiseOr, imm : Immediate::Fixed(imm), .. }) if imm == 0_u8.into()
+                => format!("{b} + {c}"),
             Type0(Gen { op, imm : Immediate::Fixed(imm), .. }) if imm == 0_u8.into()
                 => format!("{a} {op:^3} {b}"),
             Type1(Gen { op, y: Register::A, .. }) | Type2(Gen { op, y: Register::A, .. })

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -38,7 +38,6 @@ pub const NOOP_TYPE3 : Instruction = Instruction {
 };
 
 // Some tenyr ops are more than one token, so require special treatment
-#[macro_export]
 macro_rules! tenyr_get_op {
     ( $callback:ident                       ) => { { use $crate::tenyr::Opcode::*; let op = tenyr_op!( | ); $callback!(op            ) } };
 
@@ -51,14 +50,12 @@ macro_rules! tenyr_get_op {
 
 pub type InsnResult = Result<Instruction, Box<dyn std::error::Error>>;
 
-#[macro_export]
 macro_rules! tenyr_imm {
     ( $imm:expr ) => { {
         $imm.try_into().map_err::<Box<dyn std::error::Error>,_>(Into::into)?
     } };
 }
 
-#[macro_export]
 macro_rules! tenyr_type013 {
     ( $opname:ident ( $imm:expr ) $( + $y:ident )? ) => {
         Ok($crate::tenyr::Instruction {
@@ -124,7 +121,6 @@ macro_rules! tenyr_type013 {
     };
 }
 
-#[macro_export]
 macro_rules! tenyr_type2 {
     ( $opname:ident $x:ident $( + $y:ident )? ) => {
         Ok($crate::tenyr::Instruction {
@@ -139,7 +135,6 @@ macro_rules! tenyr_type2 {
     };
 }
 
-#[macro_export]
 macro_rules! tenyr_rhs {
     ( $( $x:ident + )? ( $imm:expr ) ) => {
         {

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -661,7 +661,7 @@ impl fmt::Display for Instruction {
                 => format!("{a} + {c}"),
             Type0(Gen { op, imm : Immediate::Fixed(imm), .. }) if imm == 0_u8.into()
                 => format!("{a} {op:^3} {b}"),
-            Type1(Gen { op, y, .. }) | Type2(Gen { op, y, .. }) if y == Register::A
+            Type1(Gen { op, y: Register::A, .. }) | Type2(Gen { op, y: Register::A, .. })
                 => format!("{a} {op:^3} {b}"),
             Type0(Gen { op, imm : Immediate::Fixed(imm), .. }) if i32::from(imm) < 0
                 => format!("{a} {op:^3} {b} - {imm}", imm=(-i32::from(imm))),


### PR DESCRIPTION
- Revert "Make make_constant infallible"
- Regularize columnar presence of `?`
- Tweak patterns for canonicalization
- Drop `macro_export` for internal macros
- Drop some clippy exemptions
- Improve readability of generated assembly
- Impl `From<>` for `Atom`, and use `Cow`
- Use new `Atom` conversions
- Stop justifying operation
