### PR TITLE
Expand support for `@+` shorthand

### DIFF
--- a/test/Allocate.tas
+++ b/test/Allocate.tas
@@ -28,7 +28,7 @@ _8Allocate02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -46,7 +46,7 @@ _8Allocate01_3b22array_allocate_boolean04_3b28295b1Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue
 .L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue:
      P  <- [O]
 
@@ -63,7 +63,7 @@ _8Allocate01_3b19array_allocate_char04_3b28295b1C:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue
 .L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue:
      P  <- [O]
 
@@ -80,7 +80,7 @@ _8Allocate01_3b20array_allocate_float04_3b28295b1F:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue
 .L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue:
      P  <- [O]
 
@@ -98,7 +98,7 @@ _8Allocate01_3b21array_allocate_double04_3b28295b1D:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue
 .L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue:
      P  <- [O]
 
@@ -115,7 +115,7 @@ _8Allocate01_3b19array_allocate_byte04_3b28295b1B:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue
 .L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue:
      P  <- [O]
 
@@ -132,7 +132,7 @@ _8Allocate01_3b20array_allocate_short04_3b28295b1S:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue
 .L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue:
      P  <- [O]
 
@@ -149,7 +149,7 @@ _8Allocate01_3b18array_allocate_int04_3b28295b1I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue
 .L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue:
      P  <- [O]
 
@@ -167,7 +167,7 @@ _8Allocate01_3b19array_allocate_long04_3b28295b1J:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue
 .L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue:
      P  <- [O]
 
@@ -188,7 +188,7 @@ _8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object01_3b
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue
 .L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 
@@ -205,7 +205,7 @@ _8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object01
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue + P
+     P  <-  P + @+.L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue
 .L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 

--- a/test/Allocate.tas
+++ b/test/Allocate.tas
@@ -28,7 +28,7 @@ _8Allocate02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_8Allocate02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -46,7 +46,7 @@ _8Allocate01_3b22array_allocate_boolean04_3b28295b1Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue + P
 .L_8Allocate01_3b22array_allocate_boolean04_3b28295b1Z01_3b10__epilogue:
      P  <- [O]
 
@@ -63,7 +63,7 @@ _8Allocate01_3b19array_allocate_char04_3b28295b1C:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue + P
 .L_8Allocate01_3b19array_allocate_char04_3b28295b1C01_3b10__epilogue:
      P  <- [O]
 
@@ -80,7 +80,7 @@ _8Allocate01_3b20array_allocate_float04_3b28295b1F:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue + P
 .L_8Allocate01_3b20array_allocate_float04_3b28295b1F01_3b10__epilogue:
      P  <- [O]
 
@@ -98,7 +98,7 @@ _8Allocate01_3b21array_allocate_double04_3b28295b1D:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue + P
 .L_8Allocate01_3b21array_allocate_double04_3b28295b1D01_3b10__epilogue:
      P  <- [O]
 
@@ -115,7 +115,7 @@ _8Allocate01_3b19array_allocate_byte04_3b28295b1B:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue + P
 .L_8Allocate01_3b19array_allocate_byte04_3b28295b1B01_3b10__epilogue:
      P  <- [O]
 
@@ -132,7 +132,7 @@ _8Allocate01_3b20array_allocate_short04_3b28295b1S:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue + P
 .L_8Allocate01_3b20array_allocate_short04_3b28295b1S01_3b10__epilogue:
      P  <- [O]
 
@@ -149,7 +149,7 @@ _8Allocate01_3b18array_allocate_int04_3b28295b1I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue + P
 .L_8Allocate01_3b18array_allocate_int04_3b28295b1I01_3b10__epilogue:
      P  <- [O]
 
@@ -167,7 +167,7 @@ _8Allocate01_3b19array_allocate_long04_3b28295b1J:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue + P
 .L_8Allocate01_3b19array_allocate_long04_3b28295b1J01_3b10__epilogue:
      P  <- [O]
 
@@ -188,7 +188,7 @@ _8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object01_3b
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue + P
 .L_8Allocate01_3b21array_allocate_object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 
@@ -205,7 +205,7 @@ _8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object01
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue + P
 .L_8Allocate01_3b22array_allocate_objects04_3b28295b5Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 

--- a/test/Compare.tas
+++ b/test/Compare.tas
@@ -36,7 +36,7 @@ _7Compare02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -58,14 +58,14 @@ _7Compare01_3b2lt02_3b282FF01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B >= A
-     P  <-  (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__11
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -87,14 +87,14 @@ _7Compare01_3b2le02_3b282FF01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  A < B
-     P  <-  (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__11
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -116,14 +116,14 @@ _7Compare01_3b2eq02_3b282FF01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__10 - (. + 1)) &~ B + P
+     P  <-  @+.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__10 &~ B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__11
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -145,14 +145,14 @@ _7Compare01_3b2gt02_3b282FF01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  A >= B
-     P  <-  (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__11
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -174,14 +174,14 @@ _7Compare01_3b2ge02_3b282FF01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B < A
-     P  <-  (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__11
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -203,14 +203,14 @@ _7Compare01_3b2ne02_3b282FF01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__11
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  (.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -236,14 +236,14 @@ _7Compare01_3b2lt02_3b282DD01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B >= A
-     P  <-  (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__11
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -269,14 +269,14 @@ _7Compare01_3b2le02_3b282DD01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  A < B
-     P  <-  (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__11
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -302,14 +302,14 @@ _7Compare01_3b2eq02_3b282DD01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__10 - (. + 1)) &~ B + P
+     P  <-  @+.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__10 &~ B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__11
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -335,14 +335,14 @@ _7Compare01_3b2gt02_3b282DD01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  A >= B
-     P  <-  (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__11
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -368,14 +368,14 @@ _7Compare01_3b2ge02_3b282DD01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B < A
-     P  <-  (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__11
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -401,14 +401,14 @@ _7Compare01_3b2ne02_3b282DD01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__11
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -434,14 +434,14 @@ _7Compare01_3b2lt02_3b282JJ01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B >= A
-     P  <-  (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__11
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -467,14 +467,14 @@ _7Compare01_3b2le02_3b282JJ01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  A < B
-     P  <-  (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__11
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -500,14 +500,14 @@ _7Compare01_3b2eq02_3b282JJ01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__10 - (. + 1)) &~ B + P
+     P  <-  @+.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__10 &~ B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__11
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -533,14 +533,14 @@ _7Compare01_3b2gt02_3b282JJ01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  A >= B
-     P  <-  (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__11
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -566,14 +566,14 @@ _7Compare01_3b2ge02_3b282JJ01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B < A
-     P  <-  (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__11
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -599,14 +599,14 @@ _7Compare01_3b2ne02_3b282JJ01_291Z:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__10 - (. + 1)) & B + P
+     P  <-  @+.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__10 & B + P
      B  <-  1
-     P  <-  P + (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__11
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__10:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  (.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue + P
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]

--- a/test/Compare.tas
+++ b/test/Compare.tas
@@ -36,7 +36,7 @@ _7Compare02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_7Compare02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -65,7 +65,7 @@ _7Compare01_3b2lt02_3b282FF01_291Z:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  @+.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue
 .L_7Compare01_3b2lt02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -94,7 +94,7 @@ _7Compare01_3b2le02_3b282FF01_291Z:
      C  <-  0
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  @+.L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue
 .L_7Compare01_3b2le02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -123,7 +123,7 @@ _7Compare01_3b2eq02_3b282FF01_291Z:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  @+.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue
 .L_7Compare01_3b2eq02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -152,7 +152,7 @@ _7Compare01_3b2gt02_3b282FF01_291Z:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  @+.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue
 .L_7Compare01_3b2gt02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -181,7 +181,7 @@ _7Compare01_3b2ge02_3b282FF01_291Z:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  @+.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue
 .L_7Compare01_3b2ge02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -210,7 +210,7 @@ _7Compare01_3b2ne02_3b282FF01_291Z:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b4__11:
      C  -> [O + 3]
-     P  <-  @+.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue
 .L_7Compare01_3b2ne02_3b282FF01_291Z01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -243,7 +243,7 @@ _7Compare01_3b2lt02_3b282DD01_291Z:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue
 .L_7Compare01_3b2lt02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -276,7 +276,7 @@ _7Compare01_3b2le02_3b282DD01_291Z:
      C  <-  0
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue
 .L_7Compare01_3b2le02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -309,7 +309,7 @@ _7Compare01_3b2eq02_3b282DD01_291Z:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue
 .L_7Compare01_3b2eq02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -342,7 +342,7 @@ _7Compare01_3b2gt02_3b282DD01_291Z:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue
 .L_7Compare01_3b2gt02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -375,7 +375,7 @@ _7Compare01_3b2ge02_3b282DD01_291Z:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue
 .L_7Compare01_3b2ge02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -408,7 +408,7 @@ _7Compare01_3b2ne02_3b282DD01_291Z:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue
 .L_7Compare01_3b2ne02_3b282DD01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -441,7 +441,7 @@ _7Compare01_3b2lt02_3b282JJ01_291Z:
      C  <-  0
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue
 .L_7Compare01_3b2lt02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -474,7 +474,7 @@ _7Compare01_3b2le02_3b282JJ01_291Z:
      C  <-  0
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue
 .L_7Compare01_3b2le02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -507,7 +507,7 @@ _7Compare01_3b2eq02_3b282JJ01_291Z:
      C  <-  0
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue
 .L_7Compare01_3b2eq02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -540,7 +540,7 @@ _7Compare01_3b2gt02_3b282JJ01_291Z:
      C  <-  0
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue
 .L_7Compare01_3b2gt02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -573,7 +573,7 @@ _7Compare01_3b2ge02_3b282JJ01_291Z:
      C  <-  0
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue
 .L_7Compare01_3b2ge02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -606,7 +606,7 @@ _7Compare01_3b2ne02_3b282JJ01_291Z:
      C  <-  0
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b4__11:
      C  -> [O + 5]
-     P  <-  @+.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue + P
+     P  <-  P + @+.L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue
 .L_7Compare01_3b2ne02_3b282JJ01_291Z01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]

--- a/test/Constant.tas
+++ b/test/Constant.tas
@@ -30,7 +30,7 @@ _8Constant02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -42,7 +42,7 @@ _8Constant01_3b12constant_int03_3b28291I:
 .L_8Constant01_3b12constant_int03_3b28291I01_3b3__0:
      B  <-  1
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue + P
 .L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue:
      P  <- [O]
 
@@ -55,7 +55,7 @@ _8Constant01_3b13constant_long03_3b28291J:
      C  <-  1
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue + P
 .L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -70,7 +70,7 @@ _8Constant01_3b14constant_float03_3b28291F:
      B  <-  A | A
      B  <-  B + C
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue + P
 .L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue:
      P  <- [O]
 
@@ -86,7 +86,7 @@ _8Constant01_3b15constant_double03_3b28291D:
      C  <-  0
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue + P
 .L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -98,7 +98,7 @@ _8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object01_3b:
 .L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b3__0:
      B  <-  0
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue + P
 .L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 
@@ -109,7 +109,7 @@ _8Constant01_3b9large_int03_3b28291I:
 .L_8Constant01_3b9large_int03_3b28291I01_3b3__0:
      B  <-  123456
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue + P
 .L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue:
      P  <- [O]
 
@@ -122,7 +122,7 @@ _8Constant01_3b10large_long03_3b28291J:
      C  <-  123456
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue + P
 .L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -137,7 +137,7 @@ _8Constant01_3b11large_float03_3b28291F:
      B  <-  A | A
      B  <-  B + C
      B  -> [O + 2]
-     P  <-  (.L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue + P
 .L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue:
      P  <- [O]
 
@@ -153,7 +153,7 @@ _8Constant01_3b12large_double03_3b28291D:
      C  <-  0
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue + P
 .L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]

--- a/test/Constant.tas
+++ b/test/Constant.tas
@@ -30,7 +30,7 @@ _8Constant02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_8Constant02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -42,7 +42,7 @@ _8Constant01_3b12constant_int03_3b28291I:
 .L_8Constant01_3b12constant_int03_3b28291I01_3b3__0:
      B  <-  1
      B  -> [O + 2]
-     P  <-  @+.L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue
 .L_8Constant01_3b12constant_int03_3b28291I01_3b10__epilogue:
      P  <- [O]
 
@@ -55,7 +55,7 @@ _8Constant01_3b13constant_long03_3b28291J:
      C  <-  1
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  @+.L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue
 .L_8Constant01_3b13constant_long03_3b28291J01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -70,7 +70,7 @@ _8Constant01_3b14constant_float03_3b28291F:
      B  <-  A | A
      B  <-  B + C
      B  -> [O + 2]
-     P  <-  @+.L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue
 .L_8Constant01_3b14constant_float03_3b28291F01_3b10__epilogue:
      P  <- [O]
 
@@ -86,7 +86,7 @@ _8Constant01_3b15constant_double03_3b28291D:
      C  <-  0
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  @+.L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue
 .L_8Constant01_3b15constant_double03_3b28291D01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -98,7 +98,7 @@ _8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object01_3b:
 .L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b3__0:
      B  <-  0
      B  -> [O + 2]
-     P  <-  @+.L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue
 .L_8Constant01_3b15constant_Object03_3b28295Ljava01_2f4lang01_2f6Object02_3b3b10__epilogue:
      P  <- [O]
 
@@ -109,7 +109,7 @@ _8Constant01_3b9large_int03_3b28291I:
 .L_8Constant01_3b9large_int03_3b28291I01_3b3__0:
      B  <-  123456
      B  -> [O + 2]
-     P  <-  @+.L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue
 .L_8Constant01_3b9large_int03_3b28291I01_3b10__epilogue:
      P  <- [O]
 
@@ -122,7 +122,7 @@ _8Constant01_3b10large_long03_3b28291J:
      C  <-  123456
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  @+.L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue
 .L_8Constant01_3b10large_long03_3b28291J01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]
@@ -137,7 +137,7 @@ _8Constant01_3b11large_float03_3b28291F:
      B  <-  A | A
      B  <-  B + C
      B  -> [O + 2]
-     P  <-  @+.L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue
 .L_8Constant01_3b11large_float03_3b28291F01_3b10__epilogue:
      P  <- [O]
 
@@ -153,7 +153,7 @@ _8Constant01_3b12large_double03_3b28291D:
      C  <-  0
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  @+.L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue + P
+     P  <-  P + @+.L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue
 .L_8Constant01_3b12large_double03_3b28291D01_3b10__epilogue:
      O  <-  O - 1
      P  <- [O]

--- a/test/Deep.tas
+++ b/test/Deep.tas
@@ -30,7 +30,7 @@ _4Deep02_3b3c4init04_3e3b28291V:
      D  <-  0
      D  -> [B + (@_4Deep01_3b3sum01_3b1J01_3b12field_offset + 1)]
      C  -> [B + (@_4Deep01_3b3sum01_3b1J01_3b12field_offset + 0)]
-     P  <-  (.L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -44,7 +44,7 @@ _4Deep01_3b3add02_3b282II01_291I:
      C  <- [O + 2]
      B  <-  B + C
      B  -> [O + 3]
-     P  <-  (.L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue + P
 .L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -136,7 +136,7 @@ _4Deep01_3b7calling03_3b28291J:
      B  <-  C @ 31
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue + P
 .L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue:
      P  <- [O]
 

--- a/test/Deep.tas
+++ b/test/Deep.tas
@@ -30,7 +30,7 @@ _4Deep02_3b3c4init04_3e3b28291V:
      D  <-  0
      D  -> [B + (@_4Deep01_3b3sum01_3b1J01_3b12field_offset + 1)]
      C  -> [B + (@_4Deep01_3b3sum01_3b1J01_3b12field_offset + 0)]
-     P  <-  @+.L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_4Deep02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -44,7 +44,7 @@ _4Deep01_3b3add02_3b282II01_291I:
      C  <- [O + 2]
      B  <-  B + C
      B  -> [O + 3]
-     P  <-  @+.L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue
 .L_4Deep01_3b3add02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -136,7 +136,7 @@ _4Deep01_3b7calling03_3b28291J:
      B  <-  C @ 31
      B  -> [O + 2]
      C  -> [O + 3]
-     P  <-  @+.L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue + P
+     P  <-  P + @+.L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue
 .L_4Deep01_3b7calling03_3b28291J01_3b10__epilogue:
      P  <- [O]
 

--- a/test/Empty.tas
+++ b/test/Empty.tas
@@ -19,7 +19,7 @@ _5Empty02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -29,7 +29,7 @@ _5Empty01_3b5empty03_3b28291V:
 .L_5Empty01_3b5empty03_3b28291V01_3b10__prologue:
      O  <-  O - 1
 .L_5Empty01_3b5empty03_3b28291V01_3b3__0:
-     P  <-  (.L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue + P
 .L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Empty.tas
+++ b/test/Empty.tas
@@ -19,7 +19,7 @@ _5Empty02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_5Empty02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -29,7 +29,7 @@ _5Empty01_3b5empty03_3b28291V:
 .L_5Empty01_3b5empty03_3b28291V01_3b10__prologue:
      O  <-  O - 1
 .L_5Empty01_3b5empty03_3b28291V01_3b3__0:
-     P  <-  @+.L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue
 .L_5Empty01_3b5empty03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Except.tas
+++ b/test/Except.tas
@@ -23,7 +23,7 @@ _6Except02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -43,7 +43,7 @@ _6Except01_3b3sub02_3b281I01_291I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  (.L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue + P
 .L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]
@@ -61,7 +61,7 @@ _6Except01_3b6except02_3b281I01_291I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 3]
-     P  <-  (.L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue + P
 .L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -81,7 +81,7 @@ _6Except01_3b6lastly02_3b281I01_291I:
      B  -> [O + 3]
      B  <-  -1
      B  -> [O + 4]
-     P  <-  (.L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue + P
 .L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 3
      P  <- [O - 2]
@@ -101,7 +101,7 @@ _6Except01_3b13except_lastly02_3b281I01_291I:
      B  -> [O + 4]
      B  <-  -1
      B  -> [O + 5]
-     P  <-  (.L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue + P
 .L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -121,7 +121,7 @@ _6Except01_3b14except2_lastly02_3b281I01_291I:
      B  -> [O + 4]
      B  <-  -1
      B  -> [O + 5]
-     P  <-  (.L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue + P
 .L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]

--- a/test/Except.tas
+++ b/test/Except.tas
@@ -23,7 +23,7 @@ _6Except02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_6Except02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -43,7 +43,7 @@ _6Except01_3b3sub02_3b281I01_291I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 2]
-     P  <-  @+.L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue
 .L_6Except01_3b3sub02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]
@@ -61,7 +61,7 @@ _6Except01_3b6except02_3b281I01_291I:
      B  <- [O + 1]
      O  <-  O + 1
      B  -> [O + 3]
-     P  <-  @+.L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue
 .L_6Except01_3b6except02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -81,7 +81,7 @@ _6Except01_3b6lastly02_3b281I01_291I:
      B  -> [O + 3]
      B  <-  -1
      B  -> [O + 4]
-     P  <-  @+.L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue
 .L_6Except01_3b6lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 3
      P  <- [O - 2]
@@ -101,7 +101,7 @@ _6Except01_3b13except_lastly02_3b281I01_291I:
      B  -> [O + 4]
      B  <-  -1
      B  -> [O + 5]
-     P  <-  @+.L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue
 .L_6Except01_3b13except_lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]
@@ -121,7 +121,7 @@ _6Except01_3b14except2_lastly02_3b281I01_291I:
      B  -> [O + 4]
      B  <-  -1
      B  -> [O + 5]
-     P  <-  @+.L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue
 .L_6Except01_3b14except2_lastly02_3b281I01_291I01_3b10__epilogue:
      O  <-  O + 4
      P  <- [O - 3]

--- a/test/Expr.tas
+++ b/test/Expr.tas
@@ -19,7 +19,7 @@ _4Expr02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -45,7 +45,7 @@ _4Expr01_3b4expr02_3b282II01_291I:
      P  <-  @+.L_4Expr01_3b4expr02_3b282II01_291I01_3b3__0 & B + P
      B  <- [O + 3]
      B  -> [O + 3]
-     P  <-  @+.L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue
 .L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Expr.tas
+++ b/test/Expr.tas
@@ -19,7 +19,7 @@ _4Expr02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_4Expr02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -42,10 +42,10 @@ _4Expr01_3b4expr02_3b282II01_291I:
      B  <- [O + 3]
      C  <- [O + 2]
      B  <-  B < C
-     P  <-  (.L_4Expr01_3b4expr02_3b282II01_291I01_3b3__0 - (. + 1)) & B + P
+     P  <-  @+.L_4Expr01_3b4expr02_3b282II01_291I01_3b3__0 & B + P
      B  <- [O + 3]
      B  -> [O + 3]
-     P  <-  (.L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue + P
 .L_4Expr01_3b4expr02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Fields.tas
+++ b/test/Fields.tas
@@ -40,7 +40,7 @@ _6Fields02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -80,9 +80,9 @@ _6Fields01_3b13access_fields03_3b28291V:
      C  <- [O + 2]
      D  <- [C + (@_6Fields01_3b10truthiness01_3b1Z01_3b12field_offset + 0)]
      C  <-  C == A
-     P  <-  (.L_6Fields01_3b13access_fields03_3b28291V01_3b4__32 - (. + 1)) &~ C + P
+     P  <-  @+.L_6Fields01_3b13access_fields03_3b28291V01_3b4__32 &~ C + P
      C  <-  1
-     P  <-  P + (.L_6Fields01_3b13access_fields03_3b28291V01_3b4__33 - (. + 1))
+     P  <-  P + @+.L_6Fields01_3b13access_fields03_3b28291V01_3b4__33
 .L_6Fields01_3b13access_fields03_3b28291V01_3b4__32:
      D  <-  0
 .L_6Fields01_3b13access_fields03_3b28291V01_3b4__33:
@@ -94,7 +94,7 @@ _6Fields01_3b13access_fields03_3b28291V:
      D  <-  D << 16
      D  <-  D >> 16
      D  -> [C + (@_6Fields01_3b14diminutiveness01_3b1S01_3b12field_offset + 0)]
-     P  <-  (.L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue + P
 .L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -104,12 +104,12 @@ _6Fields01_3b14access_statics03_3b28291V:
 .L_6Fields01_3b14access_statics03_3b28291V01_3b10__prologue:
      O  <-  O - 1
 .L_6Fields01_3b14access_statics03_3b28291V01_3b3__0:
-     B  <- [P + ((@_6Fields01_3b17static_numerosity01_3b1I01_3b6static - (. + 1)) + 0)]
+     B  <- [P + (@+@_6Fields01_3b17static_numerosity01_3b1I01_3b6static + 0)]
      C  <-  1
      B  <-  B + C
-     B  -> [P + ((@_6Fields01_3b17static_numerosity01_3b1I01_3b6static - (. + 1)) + 0)]
-     B  <- [P + ((@_6Fields01_3b13static_length01_3b1J01_3b6static - (. + 1)) + 0)]
-     C  <- [P + ((@_6Fields01_3b13static_length01_3b1J01_3b6static - (. + 1)) + 1)]
+     B  -> [P + (@+@_6Fields01_3b17static_numerosity01_3b1I01_3b6static + 0)]
+     B  <- [P + (@+@_6Fields01_3b13static_length01_3b1J01_3b6static + 0)]
+     C  <- [P + (@+@_6Fields01_3b13static_length01_3b1J01_3b6static + 1)]
      D  <-  0
      E  <-  1
      O  <-  O - 4
@@ -121,25 +121,25 @@ _6Fields01_3b14access_statics03_3b28291V:
      P  <-  P + @+_5tyrga01_2f7Builtin01_3b3sub02_3b282JJ01_291J
      C  <- [O + 1]
      O  <-  O + 1
-     C  -> [P + ((@_6Fields01_3b13static_length01_3b1J01_3b6static - (. + 1)) + 1)]
+     C  -> [P + (@+@_6Fields01_3b13static_length01_3b1J01_3b6static + 1)]
      B  <- [O + 1]
      O  <-  O + 1
-     B  -> [P + ((@_6Fields01_3b13static_length01_3b1J01_3b6static - (. + 1)) + 0)]
-     B  <- [P + ((@_6Fields01_3b17static_truthiness01_3b1Z01_3b6static - (. + 1)) + 0)]
+     B  -> [P + (@+@_6Fields01_3b13static_length01_3b1J01_3b6static + 0)]
+     B  <- [P + (@+@_6Fields01_3b17static_truthiness01_3b1Z01_3b6static + 0)]
      B  <-  B == A
-     P  <-  (.L_6Fields01_3b14access_statics03_3b28291V01_3b4__26 - (. + 1)) &~ B + P
+     P  <-  @+.L_6Fields01_3b14access_statics03_3b28291V01_3b4__26 &~ B + P
      B  <-  1
-     P  <-  P + (.L_6Fields01_3b14access_statics03_3b28291V01_3b4__27 - (. + 1))
+     P  <-  P + @+.L_6Fields01_3b14access_statics03_3b28291V01_3b4__27
 .L_6Fields01_3b14access_statics03_3b28291V01_3b4__26:
      C  <-  0
 .L_6Fields01_3b14access_statics03_3b28291V01_3b4__27:
-     C  -> [P + ((@_6Fields01_3b17static_truthiness01_3b1Z01_3b6static - (. + 1)) + 0)]
-     C  <- [P + ((@_6Fields01_3b21static_diminutiveness01_3b1S01_3b6static - (. + 1)) + 0)]
+     C  -> [P + (@+@_6Fields01_3b17static_truthiness01_3b1Z01_3b6static + 0)]
+     C  <- [P + (@+@_6Fields01_3b21static_diminutiveness01_3b1S01_3b6static + 0)]
      C  <-  A - C
      C  <-  C << 16
      C  <-  C >> 16
-     C  -> [P + ((@_6Fields01_3b21static_diminutiveness01_3b1S01_3b6static - (. + 1)) + 0)]
-     P  <-  (.L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue - (. + 1)) + P
+     C  -> [P + (@+@_6Fields01_3b21static_diminutiveness01_3b1S01_3b6static + 0)]
+     P  <-  @+.L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue + P
 .L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Fields.tas
+++ b/test/Fields.tas
@@ -40,7 +40,7 @@ _6Fields02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_6Fields02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -94,7 +94,7 @@ _6Fields01_3b13access_fields03_3b28291V:
      D  <-  D << 16
      D  <-  D >> 16
      D  -> [C + (@_6Fields01_3b14diminutiveness01_3b1S01_3b12field_offset + 0)]
-     P  <-  @+.L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue
 .L_6Fields01_3b13access_fields03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -139,7 +139,7 @@ _6Fields01_3b14access_statics03_3b28291V:
      C  <-  C << 16
      C  <-  C >> 16
      C  -> [P + (@+@_6Fields01_3b21static_diminutiveness01_3b1S01_3b6static + 0)]
-     P  <-  @+.L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue
 .L_6Fields01_3b14access_statics03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/GCD.tas
+++ b/test/GCD.tas
@@ -19,7 +19,7 @@ _3GCD02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,26 +32,26 @@ _3GCD01_3b3gcd02_3b282II01_291I:
      B  <- [O + 3]
      C  <- [O + 2]
      B  <-  B == C
-     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__24 - (. + 1)) & B + P
+     P  <-  @+.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__24 & B + P
      B  <- [O + 3]
      C  <- [O + 2]
      B  <-  C >= B
-     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__17 - (. + 1)) & B + P
+     P  <-  @+.L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__17 & B + P
      B  <- [O + 3]
      C  <- [O + 2]
      B  <-  B - C
      B  -> [O + 3]
-     P  <-  P + (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b3__0 - (. + 1))
+     P  <-  P + @+.L_3GCD01_3b3gcd02_3b282II01_291I01_3b3__0
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__17:
      B  <- [O + 2]
      C  <- [O + 3]
      B  <-  B - C
      B  -> [O + 2]
-     P  <-  P + (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b3__0 - (. + 1))
+     P  <-  P + @+.L_3GCD01_3b3gcd02_3b282II01_291I01_3b3__0
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__24:
      B  <- [O + 3]
      B  -> [O + 3]
-     P  <-  (.L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue + P
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/GCD.tas
+++ b/test/GCD.tas
@@ -19,7 +19,7 @@ _3GCD02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_3GCD02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -51,7 +51,7 @@ _3GCD01_3b3gcd02_3b282II01_291I:
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b4__24:
      B  <- [O + 3]
      B  -> [O + 3]
-     P  <-  @+.L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue
 .L_3GCD01_3b3gcd02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Infinite.tas
+++ b/test/Infinite.tas
@@ -20,7 +20,7 @@ _8Infinite02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Infinite.tas
+++ b/test/Infinite.tas
@@ -20,7 +20,7 @@ _8Infinite02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_8Infinite02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -30,7 +30,7 @@ _8Infinite01_3b9tiny_loop03_3b28291V:
 .L_8Infinite01_3b9tiny_loop03_3b28291V01_3b10__prologue:
      O  <-  O - 1
 .L_8Infinite01_3b9tiny_loop03_3b28291V01_3b3__0:
-     P  <-  P + (.L_8Infinite01_3b9tiny_loop03_3b28291V01_3b3__0 - (. + 1))
+     P  <-  P + @+.L_8Infinite01_3b9tiny_loop03_3b28291V01_3b3__0
 .L_8Infinite01_3b9tiny_loop03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]
@@ -46,7 +46,7 @@ _8Infinite01_3b4loop03_3b28291V:
      B  <- [O + 2]
      B  <-  B + 1
      B  -> [O + 2]
-     P  <-  P + (.L_8Infinite01_3b4loop03_3b28291V01_3b3__2 - (. + 1))
+     P  <-  P + @+.L_8Infinite01_3b4loop03_3b28291V01_3b3__2
 .L_8Infinite01_3b4loop03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Loops.tas
+++ b/test/Loops.tas
@@ -19,7 +19,7 @@ _5Loops02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -105,7 +105,7 @@ _5Loops01_3b5deep503_3b28291I:
 .L_5Loops01_3b5deep503_3b28291I01_3b4__85:
      B  <- [O + 7]
      B  -> [O + 7]
-     P  <-  @+.L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue + P
+     P  <-  P + @+.L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue
 .L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue:
      O  <-  O + 6
      P  <- [O - 5]

--- a/test/Loops.tas
+++ b/test/Loops.tas
@@ -19,7 +19,7 @@ _5Loops02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_5Loops02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -37,35 +37,35 @@ _5Loops01_3b5deep503_3b28291I:
      B  <- [O + 6]
      C  <-  3
      B  <-  B >= C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__85 - (. + 1)) & B + P
+     P  <-  @+.L_5Loops01_3b5deep503_3b28291I01_3b4__85 & B + P
      B  <-  0
      B  -> [O + 5]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__11:
      B  <- [O + 5]
      C  <-  3
      B  <-  B >= C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__79 - (. + 1)) & B + P
+     P  <-  @+.L_5Loops01_3b5deep503_3b28291I01_3b4__79 & B + P
      B  <-  0
      B  -> [O + 4]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__18:
      B  <- [O + 4]
      C  <-  3
      B  <-  B >= C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__73 - (. + 1)) & B + P
+     P  <-  @+.L_5Loops01_3b5deep503_3b28291I01_3b4__73 & B + P
      B  <-  0
      B  -> [O + 3]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__26:
      B  <- [O + 3]
      C  <-  3
      B  <-  B >= C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__67 - (. + 1)) & B + P
+     P  <-  @+.L_5Loops01_3b5deep503_3b28291I01_3b4__67 & B + P
      B  <-  0
      B  -> [O + 2]
 .L_5Loops01_3b5deep503_3b28291I01_3b4__35:
      B  <- [O + 2]
      C  <-  3
      B  <-  B >= C
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b4__61 - (. + 1)) & B + P
+     P  <-  @+.L_5Loops01_3b5deep503_3b28291I01_3b4__61 & B + P
      B  <- [O + 7]
      C  <- [O + 6]
      D  <- [O + 5]
@@ -81,31 +81,31 @@ _5Loops01_3b5deep503_3b28291I:
      B  <- [O + 2]
      B  <-  B + 1
      B  -> [O + 2]
-     P  <-  P + (.L_5Loops01_3b5deep503_3b28291I01_3b4__35 - (. + 1))
+     P  <-  P + @+.L_5Loops01_3b5deep503_3b28291I01_3b4__35
 .L_5Loops01_3b5deep503_3b28291I01_3b4__61:
      B  <- [O + 3]
      B  <-  B + 1
      B  -> [O + 3]
-     P  <-  P + (.L_5Loops01_3b5deep503_3b28291I01_3b4__26 - (. + 1))
+     P  <-  P + @+.L_5Loops01_3b5deep503_3b28291I01_3b4__26
 .L_5Loops01_3b5deep503_3b28291I01_3b4__67:
      B  <- [O + 4]
      B  <-  B + 1
      B  -> [O + 4]
-     P  <-  P + (.L_5Loops01_3b5deep503_3b28291I01_3b4__18 - (. + 1))
+     P  <-  P + @+.L_5Loops01_3b5deep503_3b28291I01_3b4__18
 .L_5Loops01_3b5deep503_3b28291I01_3b4__73:
      B  <- [O + 5]
      B  <-  B + 1
      B  -> [O + 5]
-     P  <-  P + (.L_5Loops01_3b5deep503_3b28291I01_3b4__11 - (. + 1))
+     P  <-  P + @+.L_5Loops01_3b5deep503_3b28291I01_3b4__11
 .L_5Loops01_3b5deep503_3b28291I01_3b4__79:
      B  <- [O + 6]
      B  <-  B + 1
      B  -> [O + 6]
-     P  <-  P + (.L_5Loops01_3b5deep503_3b28291I01_3b3__4 - (. + 1))
+     P  <-  P + @+.L_5Loops01_3b5deep503_3b28291I01_3b3__4
 .L_5Loops01_3b5deep503_3b28291I01_3b4__85:
      B  <- [O + 7]
      B  -> [O + 7]
-     P  <-  (.L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue + P
 .L_5Loops01_3b5deep503_3b28291I01_3b10__epilogue:
      O  <-  O + 6
      P  <- [O - 5]

--- a/test/Native.tas
+++ b/test/Native.tas
@@ -20,7 +20,7 @@ _6Native02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,7 +32,7 @@ _6Native01_3b6caller03_3b28291V:
 .L_6Native01_3b6caller03_3b28291V01_3b3__0:
     [O] <-  P + 1
      P  <-  P + @+_6Native01_3b10nativeCall03_3b28291V
-     P  <-  @+.L_6Native01_3b6caller03_3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Native01_3b6caller03_3b28291V01_3b10__epilogue
 .L_6Native01_3b6caller03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Native.tas
+++ b/test/Native.tas
@@ -20,7 +20,7 @@ _6Native02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_6Native02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,7 +32,7 @@ _6Native01_3b6caller03_3b28291V:
 .L_6Native01_3b6caller03_3b28291V01_3b3__0:
     [O] <-  P + 1
      P  <-  P + @+_6Native01_3b10nativeCall03_3b28291V
-     P  <-  (.L_6Native01_3b6caller03_3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Native01_3b6caller03_3b28291V01_3b10__epilogue + P
 .L_6Native01_3b6caller03_3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Nest.tas
+++ b/test/Nest.tas
@@ -19,7 +19,7 @@ _4Nest02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -82,7 +82,7 @@ _4Nest01_3b4nest02_3b282II01_291I:
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b4__56:
      B  <- [O + 4]
      B  -> [O + 6]
-     P  <-  @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 5
      P  <- [O - 4]

--- a/test/Nest.tas
+++ b/test/Nest.tas
@@ -19,7 +19,7 @@ _4Nest02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_4Nest02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -37,7 +37,7 @@ _4Nest01_3b4nest02_3b282II01_291I:
      B  <- [O + 5]
      C  <- [O + 3]
      B  <-  B >= C
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__56 - (. + 1)) & B + P
+     P  <-  @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__56 & B + P
      B  <- [O + 6]
      C  <- [O + 3]
      B  <-  B + C
@@ -52,7 +52,7 @@ _4Nest01_3b4nest02_3b282II01_291I:
      B  <- [O + 2]
      C  <- [O + 5]
      B  <-  B >= C
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__53 - (. + 1)) & B + P
+     P  <-  @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__53 & B + P
      B  <- [O + 6]
      C  <- [O + 5]
      B  <-  B + C
@@ -72,17 +72,17 @@ _4Nest01_3b4nest02_3b282II01_291I:
      B  <- [O + 6]
      C  <- [O + 5]
      B  <-  B < C
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__34 - (. + 1)) & B + P
+     P  <-  @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__34 & B + P
      B  <- [O + 2]
      B  <-  B + 1
      B  -> [O + 2]
-     P  <-  P + (.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__20 - (. + 1))
+     P  <-  P + @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b4__20
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b4__53:
-     P  <-  P + (.L_4Nest01_3b4nest02_3b282II01_291I01_3b3__4 - (. + 1))
+     P  <-  P + @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b3__4
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b4__56:
      B  <- [O + 4]
      B  -> [O + 6]
-     P  <-  (.L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue + P
 .L_4Nest01_3b4nest02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 5
      P  <- [O - 4]

--- a/test/Recurse.tas
+++ b/test/Recurse.tas
@@ -21,7 +21,7 @@ _7Recurse02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -37,7 +37,7 @@ _7Recurse01_3b7recurse03_3b28291V:
      B  <- [B - 1]
     [O] <-  P + 1
      P  <- [B + @_7Recurse01_3b7recurse03_3b28291V01_3b5vslot]
-     P  <-  (.L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue + P
 .L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Recurse.tas
+++ b/test/Recurse.tas
@@ -21,7 +21,7 @@ _7Recurse02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_7Recurse02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -37,7 +37,7 @@ _7Recurse01_3b7recurse03_3b28291V:
      B  <- [B - 1]
     [O] <-  P + 1
      P  <- [B + @_7Recurse01_3b7recurse03_3b28291V01_3b5vslot]
-     P  <-  @+.L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue
 .L_7Recurse01_3b7recurse03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Sieve.tas
+++ b/test/Sieve.tas
@@ -21,7 +21,7 @@ _5Sieve02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -36,7 +36,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 6]
      B  <- [O + 6]
      B  <-  A >= B
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__11 - (. + 1)) & B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__11 & B + P
      B  <- [O + 7]
      C  <-  0
      D  <-  2
@@ -45,7 +45,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 6]
      C  <-  1
      B  <-  C >= B
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__20 - (. + 1)) & B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__20 & B + P
      B  <- [O + 7]
      C  <-  1
      D  <-  3
@@ -57,7 +57,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 5]
      C  <- [O + 6]
      B  <-  B >= C
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__111 - (. + 1)) & B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__111 & B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <-  1
@@ -74,11 +74,11 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__42:
      B  <- [O + 3]
      B  <-  B == A
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) &~ B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 &~ B + P
      B  <- [O + 2]
      C  <- [O + 5]
      B  <-  B >= C
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 & B + P
      B  <- [O + 7]
      C  <- [O + 2]
      B  <- [C + B]
@@ -88,7 +88,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <-  B * C
      C  <- [O + 4]
      B  <-  C < B
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86 & B + P
      B  <- [O + 4]
      C  <- [O + 7]
      D  <- [O + 2]
@@ -101,35 +101,35 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__80 - (. + 1)) &~ B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__80 &~ B + P
      B  <-  1
      B  -> [O + 3]
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__80:
      B  <- [O + 2]
      B  <-  B + 1
      B  -> [O + 2]
-     P  <-  P + (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__42 - (. + 1))
+     P  <-  P + @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__42
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__86:
      B  <- [O + 3]
      B  <-  B == A
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__99 - (. + 1)) &~ B + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__99 &~ B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <- [O + 4]
      D  -> [C + B]
-     P  <-  P + (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__105 - (. + 1))
+     P  <-  P + @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__105
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__99:
      B  <- [O + 4]
      B  <-  B + 1
      B  -> [O + 4]
-     P  <-  P + (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__36 - (. + 1))
+     P  <-  P + @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__36
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__105:
      B  <- [O + 5]
      B  <-  B + 1
      B  -> [O + 5]
-     P  <-  P + (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__22 - (. + 1))
+     P  <-  P + @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__22
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__111:
-     P  <-  (.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue + P
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue:
      O  <-  O + 8
      P  <- [O - 7]

--- a/test/Sieve.tas
+++ b/test/Sieve.tas
@@ -21,7 +21,7 @@ _5Sieve02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_5Sieve02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -129,7 +129,7 @@ _5Sieve01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 5]
      P  <-  P + @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b4__22
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b5__111:
-     P  <-  @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue + P
+     P  <-  P + @+.L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue
 .L_5Sieve01_3b6primes03_3b285b1I01_291V01_3b10__epilogue:
      O  <-  O + 8
      P  <- [O - 7]

--- a/test/Static.tas
+++ b/test/Static.tas
@@ -22,7 +22,7 @@ _6Static02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -33,8 +33,8 @@ _6Static02_3b3c6clinit04_3e3b28291V:
      O  <-  O - 1
 .L_6Static02_3b3c6clinit04_3e3b28291V01_3b3__0:
      B  <-  3
-     B  -> [P + ((@_6Static01_3b1a01_3b1I01_3b6static - (. + 1)) + 0)]
-     P  <-  (.L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     B  -> [P + (@+@_6Static01_3b1a01_3b1I01_3b6static + 0)]
+     P  <-  @+.L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue + P
 .L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Static.tas
+++ b/test/Static.tas
@@ -22,7 +22,7 @@ _6Static02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_6Static02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -34,7 +34,7 @@ _6Static02_3b3c6clinit04_3e3b28291V:
 .L_6Static02_3b3c6clinit04_3e3b28291V01_3b3__0:
      B  <-  3
      B  -> [P + (@+@_6Static01_3b1a01_3b1I01_3b6static + 0)]
-     P  <-  @+.L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue
 .L_6Static02_3b3c6clinit04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Switch.tas
+++ b/test/Switch.tas
@@ -20,7 +20,7 @@ _6Switch02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,31 +32,31 @@ _6Switch01_3b5table02_3b282II01_291I:
 .L_6Switch01_3b5table02_3b282II01_291I01_3b3__0:
      B  <- [O + 3]
      C  <-  B < 1
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 - (. + 1)) & C + P
+     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 & C + P
      C  <-  3 < B
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 - (. + 1)) & C + P
+     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b4__36 & C + P
      P  <-  B - 1 + P
-     P  <-  P + (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__28 - (. + 1))
-     P  <-  P + (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__30 - (. + 1))
-     P  <-  P + (.L_6Switch01_3b5table02_3b282II01_291I01_3b4__34 - (. + 1))
+     P  <-  P + @+.L_6Switch01_3b5table02_3b282II01_291I01_3b4__28
+     P  <-  P + @+.L_6Switch01_3b5table02_3b282II01_291I01_3b4__30
+     P  <-  P + @+.L_6Switch01_3b5table02_3b282II01_291I01_3b4__34
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__28:
      C  <- [O + 2]
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__30:
      C  <- [O + 3]
      D  <- [O + 2]
      C  <-  C * D
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__34:
      C  <- [O + 3]
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__36:
      C  <-  0
      C  -> [O + 3]
-     P  <-  (.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -68,35 +68,35 @@ _6Switch01_3b6lookup02_3b282II01_291I:
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b3__0:
      B  <- [O + 3]
      C  <-  B == 1
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__36 - (. + 1)) & C + P
+     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__36 & C + P
      D  <-  8483
      C  <-  B == D
      C  <-  C + A
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__38 - (. + 1)) & C + P
+     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__38 & C + P
      D  <-  530
      D  <-  D ^^ 837
      C  <-  B == D
      C  <-  C + A
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__42 - (. + 1)) & C + P
-     P  <-  P + (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__44 - (. + 1))
+     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__42 & C + P
+     P  <-  P + @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__44
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__36:
      D  <- [O + 2]
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__38:
      D  <- [O + 3]
      E  <- [O + 2]
      D  <-  D * E
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__42:
      D  <- [O + 3]
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__44:
      D  <-  0
      D  -> [O + 3]
-     P  <-  (.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Switch.tas
+++ b/test/Switch.tas
@@ -20,7 +20,7 @@ _6Switch02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_6Switch02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -42,21 +42,21 @@ _6Switch01_3b5table02_3b282II01_291I:
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__28:
      C  <- [O + 2]
      C  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__30:
      C  <- [O + 3]
      D  <- [O + 2]
      C  <-  C * D
      C  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__34:
      C  <- [O + 3]
      C  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b5table02_3b282II01_291I01_3b4__36:
      C  <-  0
      C  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b5table02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -82,21 +82,21 @@ _6Switch01_3b6lookup02_3b282II01_291I:
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__36:
      D  <- [O + 2]
      D  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__38:
      D  <- [O + 3]
      E  <- [O + 2]
      D  <-  D * E
      D  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__42:
      D  <- [O + 3]
      D  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b4__44:
      D  <-  0
      D  -> [O + 3]
-     P  <-  @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue + P
+     P  <-  P + @+.L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue
 .L_6Switch01_3b6lookup02_3b282II01_291I01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/Tiny.tas
+++ b/test/Tiny.tas
@@ -21,7 +21,7 @@ _4Tiny02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -129,7 +129,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 5]
      P  <-  P + @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__22
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__111:
-     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue + P
+     P  <-  P + @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue:
      O  <-  O + 8
      P  <- [O - 7]

--- a/test/Tiny.tas
+++ b/test/Tiny.tas
@@ -21,7 +21,7 @@ _4Tiny02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_4Tiny02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -36,7 +36,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  -> [O + 6]
      B  <- [O + 6]
      B  <-  A >= B
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__11 - (. + 1)) & B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__11 & B + P
      B  <- [O + 7]
      C  <-  0
      D  <-  2
@@ -45,7 +45,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 6]
      C  <-  1
      B  <-  C >= B
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__20 - (. + 1)) & B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__20 & B + P
      B  <- [O + 7]
      C  <-  1
      D  <-  3
@@ -57,7 +57,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 5]
      C  <- [O + 6]
      B  <-  B >= C
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__111 - (. + 1)) & B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__111 & B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <-  1
@@ -74,11 +74,11 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__42:
      B  <- [O + 3]
      B  <-  B == A
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) &~ B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 &~ B + P
      B  <- [O + 2]
      C  <- [O + 5]
      B  <-  B >= C
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 & B + P
      B  <- [O + 7]
      C  <- [O + 2]
      B  <- [C + B]
@@ -88,7 +88,7 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <-  B * C
      C  <- [O + 4]
      B  <-  C < B
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 - (. + 1)) & B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86 & B + P
      B  <- [O + 4]
      C  <- [O + 7]
      D  <- [O + 2]
@@ -101,35 +101,35 @@ _4Tiny01_3b6primes03_3b285b1I01_291V:
      B  <- [O + 1]
      O  <-  O + 1
      B  <-  B == A
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__80 - (. + 1)) &~ B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__80 &~ B + P
      B  <-  1
      B  -> [O + 3]
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__80:
      B  <- [O + 2]
      B  <-  B + 1
      B  -> [O + 2]
-     P  <-  P + (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__42 - (. + 1))
+     P  <-  P + @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__42
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__86:
      B  <- [O + 3]
      B  <-  B == A
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__99 - (. + 1)) &~ B + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__99 &~ B + P
      B  <- [O + 7]
      C  <- [O + 5]
      D  <- [O + 4]
      D  -> [C + B]
-     P  <-  P + (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__105 - (. + 1))
+     P  <-  P + @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__105
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__99:
      B  <- [O + 4]
      B  <-  B + 1
      B  -> [O + 4]
-     P  <-  P + (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__36 - (. + 1))
+     P  <-  P + @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__36
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__105:
      B  <- [O + 5]
      B  <-  B + 1
      B  -> [O + 5]
-     P  <-  P + (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__22 - (. + 1))
+     P  <-  P + @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b4__22
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b5__111:
-     P  <-  (.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue + P
 .L_4Tiny01_3b6primes03_3b285b1I01_291V01_3b10__epilogue:
      O  <-  O + 8
      P  <- [O - 7]

--- a/test/Varargs.tas
+++ b/test/Varargs.tas
@@ -19,7 +19,7 @@ _7Varargs02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,7 +32,7 @@ _7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I:
      B  <- [O + 2]
      B  <- [B - 1]
      B  -> [O + 2]
-     P  <-  @+.L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue + P
+     P  <-  P + @+.L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue
 .L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/Varargs.tas
+++ b/test/Varargs.tas
@@ -19,7 +19,7 @@ _7Varargs02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_7Varargs02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -32,7 +32,7 @@ _7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I:
      B  <- [O + 2]
      B  <- [B - 1]
      B  -> [O + 2]
-     P  <-  (.L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue + P
 .L_7Varargs01_3b12takesVarargs03_3b285b5Ljava01_2f4lang01_2f6Object02_3b291I01_3b10__epilogue:
      O  <-  O + 1
      P  <- [O]

--- a/test/interesting/module/name/Packaged.tas
+++ b/test/interesting/module/name/Packaged.tas
@@ -24,7 +24,7 @@ _11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  @+.L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue
 .L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -40,7 +40,7 @@ _11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V:
      D  <-  1
      C  <-  C + D
      C  -> [B + (@_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b5field01_3b1I01_3b12field_offset + 0)]
-     P  <-  @+.L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue + P
+     P  <-  P + @+.L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue
 .L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/test/interesting/module/name/Packaged.tas
+++ b/test/interesting/module/name/Packaged.tas
@@ -24,7 +24,7 @@ _11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V:
      P  <-  P + @+_4java01_2f4lang01_2f6Object02_3b3c4init04_3e3b28291V
      B  <- [O + 1]
      O  <-  O + 1
-     P  <-  (.L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue + P
 .L_11interesting01_2f6module01_2f4name01_2f8Packaged02_3b3c4init04_3e3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]
@@ -40,7 +40,7 @@ _11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V:
      D  <-  1
      C  <-  C + D
      C  -> [B + (@_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b5field01_3b1I01_3b12field_offset + 0)]
-     P  <-  (.L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue - (. + 1)) + P
+     P  <-  @+.L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue + P
 .L_11interesting01_2f6module01_2f4name01_2f8Packaged01_3b6method03_3b28291V01_3b10__epilogue:
      O  <-  O + 2
      P  <- [O - 1]

--- a/tyrga-lib/src/exprtree.rs
+++ b/tyrga-lib/src/exprtree.rs
@@ -55,6 +55,20 @@ pub struct Expr {
 }
 
 impl Expr {
+    pub fn make_atplus_expr(a : Atom) -> Expr {
+        Expr {
+            a,
+            op : Operation::Sub,
+            b : Atom::Expression(
+                Expr {
+                    a :  ".".into(),
+                    op : Operation::Add,
+                    b :  Atom::Immediate(1),
+                }
+                .into(),
+            ),
+        }
+    }
     fn is_atplus_shorthand(&self) -> bool {
         matches!(self,
             Expr {

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -226,22 +226,7 @@ fn test_expand() -> GeneralResult<()> {
 type InsnPair = (Vec<Instruction>, Vec<Destination>);
 
 fn make_target(target : String) -> exprtree::Atom {
-    use exprtree::Atom::Immediate;
-    use exprtree::Expr;
-    use exprtree::Operation::{Add, Sub};
-
-    let b = Expr {
-        a :  ".".into(),
-        op : Add,
-        b :  Immediate(1),
-    }
-    .into();
-    Expr {
-        a : target.into(),
-        op : Sub,
-        b,
-    }
-    .into()
+    exprtree::Atom::Expression(exprtree::Expr::make_atplus_expr(target.into()).into())
 }
 
 fn make_int_branch(

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -239,11 +239,10 @@ fn make_int_branch(
     use Register::P;
 
     let (temp_reg, sequence) = comp(sm)?;
-    let imm = tenyr::Immediate::Expr(make_target(target_name));
     let branch = if invert {
-        tenyr_insn!(   P <- (imm) &~ temp_reg + P     )
+        tenyr_insn!(   P <- @+target_name &~ temp_reg + P     )
     } else {
-        tenyr_insn!(   P <- (imm) &  temp_reg + P     )
+        tenyr_insn!(   P <- @+target_name &  temp_reg + P     )
     };
     let mut v = sequence;
     v.push(branch?);

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -259,14 +259,8 @@ fn make_builtin_name(proc : &str, descriptor : &str) -> String {
 }
 
 fn make_jump(target : u16, target_name : String) -> GeneralResult<InsnPair> {
-    use crate::tenyr::InstructionType::Type3;
-    let kind = Type3(tenyr::Immediate::Expr(make_target(target_name)));
-    let insn = Instruction {
-        kind,
-        z : Register::P,
-        x : Register::P,
-        ..tenyr::NOOP_TYPE3
-    };
+    use Register::P;
+    let insn = tenyr_insn!( P <- P + @+target_name )?;
     let dests = vec![Destination::Address(target as usize)];
     Ok((vec![insn], dests))
 }

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -308,7 +308,7 @@ fn make_yield(
         })
     }
     v.extend(sm.empty());
-    v.push(tenyr_insn!( P <- @+target_name + P )?);
+    v.push(tenyr_insn!( P <- P + @+target_name )?);
 
     Ok((v, vec![])) // leaving the method is not a Destination we care about
 }

--- a/tyrga-lib/src/lib.rs
+++ b/tyrga-lib/src/lib.rs
@@ -309,8 +309,7 @@ fn make_yield(
         })
     }
     v.extend(sm.empty());
-    let ex = tenyr::Immediate::Expr(make_target(target_name));
-    v.push(tenyr_insn!( P <- (ex) + P )?);
+    v.push(tenyr_insn!( P <- @+target_name + P )?);
 
     Ok((v, vec![])) // leaving the method is not a Destination we care about
 }

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -166,6 +166,42 @@ macro_rules! tenyr_rhs {
             Ok(Instruction { $( x : $x, )? ..base }) as $crate::tenyr::InsnResult
         }
     };
+    ( $( $x:ident + )? @+$target:ident ) => {
+        {
+            let e = $crate::exprtree::Expr::make_atplus_expr($target.into()).into();
+            let kind = $crate::tenyr::InstructionType::Type3(
+                $crate::tenyr::Immediate::Expr(e)
+            );
+            let base = Instruction { kind, ..$crate::tenyr::NOOP_TYPE0 };
+            Ok(Instruction { $( x : $x, )? ..base }) as $crate::tenyr::InsnResult
+        }
+    };
+    ( @+$target:ident $( $rest:tt )+ ) => {
+        {
+            use $crate::exprtree::{Atom,Expr};
+            use $crate::exprtree::Operation;
+            use $crate::tenyr::*;
+            let base = tenyr_get_op!(tenyr_type2 $( $rest )*)?;
+            if let $crate::tenyr::InstructionType::Type2(gen) = base.kind {
+                let e = Expr {
+                    a : $target.into(),
+                    op : Operation::Sub,
+                    b : Expr {
+                        a :  ".".into(),
+                        op : Operation::Add,
+                        b :  Atom::Immediate(1),
+                    }.into(),
+                }.into();
+                let kind = $crate::tenyr::InstructionType::Type2($crate::tenyr::InsnGeneral {
+                    imm : $crate::tenyr::Immediate::Expr(e),
+                    ..gen
+                });
+                Ok(Instruction { kind, ..base }) as $crate::tenyr::InsnResult
+            } else {
+                Err("internal error - did not get expected Type2".into())
+            }
+        }
+    };
     ( $x:ident $( $rest:tt )* ) => {
         {
             use $crate::tenyr::*;
@@ -209,9 +245,27 @@ macro_rules! tenyr_insn {
     (   $z:ident   <-   $( $rhs:tt )+   ) => { Ok(Instruction { z : $z,                                               ..tenyr_rhs!( $( $rhs )+ )? }) as $crate::tenyr::InsnResult };
 }
 
+#[cfg(test)]
+fn expr_sub_one(a : exprtree::Atom) -> super::tenyr::Immediate12 {
+    Immediate12::Expr(
+        exprtree::Expr {
+            a,
+            op : exprtree::Operation::Sub,
+            b : exprtree::Expr {
+                a :  ".".into(),
+                op : exprtree::Operation::Add,
+                b :  exprtree::Atom::Immediate(1),
+            }
+            .into(),
+        }
+        .into(),
+    )
+}
+
 #[rustfmt::skip]
 #[test]
 fn test_macro_insn() -> Result<(), Box<dyn std::error::Error>> {
+    use std::convert::TryInto;
     use InstructionType::*;
     use MemoryOpType::*;
     use Opcode::*;
@@ -219,36 +273,50 @@ fn test_macro_insn() -> Result<(), Box<dyn std::error::Error>> {
 
     let three = 3;
 
-    let make = |ctor : &dyn Fn(InsnGeneral) -> InstructionType, y, op, imm : i8, z, x, dd|
-        Instruction { kind : ctor(InsnGeneral { y, op, imm : imm.into() }), z, x, dd };
+    let make = |ctor : &dyn Fn(InsnGeneral) -> InstructionType, y, op, imm, z, x, dd| Instruction {
+        kind : ctor(InsnGeneral { y, op, imm }),
+        z,
+        x,
+        dd,
+    };
+
+    let make8 = |ctor, y, op, imm : i8, z, x, dd| make(ctor, y, op, imm.into(), z, x, dd);
 
     let make3 = |imm : i32, z, x, dd|
         InsnResult::Ok(Instruction { kind : Type3(imm.try_into()?), z, x, dd });
 
-    assert_eq!(tenyr_insn!( B  <-  C  |~ D + 3      )?, make(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C >>> D + 3      )?, make(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  +  D + 3      )?, make(&Type0,D,Add            , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  *  D + 3      )?, make(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  *  D - 3      )?, make(&Type0,D,Multiply       ,-3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C                )?, make(&Type0,A,BitwiseOr      , 0_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  +  D          )?, make(&Type0,D,Add            , 0_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  |~ D          )?, make(&Type0,D,BitwiseOrn     , 0_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  ^^ 3          )?, make(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  3  *  C          )?, make(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  3  *  C + D      )?, make(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!([B] <-  3  ^^ C + D      )?, make(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ));
-    assert_eq!(tenyr_insn!( B  -> [3  &~ C + D]     )?, make(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight));
-    assert_eq!(tenyr_insn!( B  <- [3  @  C + D]     )?, make(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ));
-    assert_eq!(tenyr_insn!( B  <-  C  |~ D + (three))?, make(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C >>> D + (three))?, make(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  +  D + (three))?, make(&Type0,D,Add            , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  *  D + (three))?, make(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  C  ^^ (three)    )?, make(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  (three) * C      )?, make(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!( B  <-  (three) * C + D  )?, make(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ));
-    assert_eq!(tenyr_insn!([B] <-  (three) ^^ C + D )?, make(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ));
-    assert_eq!(tenyr_insn!( B  -> [(three) &~ C + D])?, make(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight));
-    assert_eq!(tenyr_insn!( B  <- [(three) @  C + D])?, make(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ));
+    let dest = "destination_label";
+
+    let imm = expr_sub_one(dest.into());
+    let im2 = imm.clone();
+
+    assert_eq!(tenyr_insn!( B  <- @+dest   &  C + D )?, make (&Type2,D,BitwiseAnd     , imm ,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <- @+dest   &~ C + D )?, make (&Type2,D,BitwiseAndn    , im2 ,B,C,NoLoad    ));
+
+    assert_eq!(tenyr_insn!( B  <-  C  |~ D + 3      )?, make8(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C >>> D + 3      )?, make8(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  +  D + 3      )?, make8(&Type0,D,Add            , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  *  D + 3      )?, make8(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  *  D - 3      )?, make8(&Type0,D,Multiply       ,-3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C                )?, make8(&Type0,A,BitwiseOr      , 0_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  +  D          )?, make8(&Type0,D,Add            , 0_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  |~ D          )?, make8(&Type0,D,BitwiseOrn     , 0_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  ^^ 3          )?, make8(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  3  *  C          )?, make8(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  3  *  C + D      )?, make8(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!([B] <-  3  ^^ C + D      )?, make8(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ));
+    assert_eq!(tenyr_insn!( B  -> [3  &~ C + D]     )?, make8(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight));
+    assert_eq!(tenyr_insn!( B  <- [3  @  C + D]     )?, make8(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ));
+    assert_eq!(tenyr_insn!( B  <-  C  |~ D + (three))?, make8(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C >>> D + (three))?, make8(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  +  D + (three))?, make8(&Type0,D,Add            , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  *  D + (three))?, make8(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  C  ^^ (three)    )?, make8(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  (three) * C      )?, make8(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!( B  <-  (three) * C + D  )?, make8(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ));
+    assert_eq!(tenyr_insn!([B] <-  (three) ^^ C + D )?, make8(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ));
+    assert_eq!(tenyr_insn!( B  -> [(three) &~ C + D])?, make8(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight));
+    assert_eq!(tenyr_insn!( B  <- [(three) @  C + D])?, make8(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ));
     assert_eq!(tenyr_insn!( B  <-  C  +  0x12345    )?, make3( 0x12345_i32,B,C,NoLoad)?);
     assert_eq!(tenyr_insn!( B  <-  C  -  0x12345    )?, make3(-0x12345_i32,B,C,NoLoad)?);
     assert_eq!(tenyr_insn!( B  <-        0x12345    )?, make3( 0x12345_i32,B,A,NoLoad)?);
@@ -263,12 +331,14 @@ fn test_macro_insn() -> Result<(), Box<dyn std::error::Error>> {
 #[macro_export]
 macro_rules! tenyr_insn_list {
     () => { std::iter::empty() };
-    ( $lhs:tt <- $a:tt $op:tt$op2:tt $b:tt $( + $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- $a $op$op2 $b $( + $c )?  )?).chain(tenyr_insn_list!($( $tok )*)) };
-    ( $lhs:tt <- $a:tt $op:tt        $b:tt $( + $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- $a $op     $b $( + $c )?  )?).chain(tenyr_insn_list!($( $tok )*)) };
-    ( $lhs:tt <- $a:tt $op:tt$op2:tt $b:tt $( - $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- $a $op$op2 $b $( - $c )?  )?).chain(tenyr_insn_list!($( $tok )*)) };
-    ( $lhs:tt <- $a:tt $op:tt        $b:tt $( - $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- $a $op     $b $( - $c )?  )?).chain(tenyr_insn_list!($( $tok )*)) };
-    ( $lhs:tt <- $rhs:tt                                 ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- $rhs                      )?).chain(tenyr_insn_list!($( $tok )*)) };
-    ( $lhs:tt -> $rhs:tt                                 ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs -> $rhs                      )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt <-   $a:tt $op:tt$op2:tt $b:tt $( + $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <-   $a $op$op2 $b $( + $c )? )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt <-   $a:tt $op:tt        $b:tt $( + $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <-   $a $op     $b $( + $c )? )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt <- @+$a:tt $op:tt$op2:tt $b:tt $( + $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- @+$a $op$op2 $b $( + $c )? )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt <- @+$a:tt $op:tt        $b:tt $( + $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- @+$a $op     $b $( + $c )? )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt <-   $a:tt $op:tt$op2:tt $b:tt $( - $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <-   $a $op$op2 $b $( - $c )? )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt <-   $a:tt $op:tt        $b:tt $( - $c:tt )? ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <-   $a $op     $b $( - $c )? )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt <- $rhs:tt                                   ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs <- $rhs                       )?).chain(tenyr_insn_list!($( $tok )*)) };
+    ( $lhs:tt -> $rhs:tt                                   ; $( $tok:tt )* ) => { std::iter::once(tenyr_insn!($lhs -> $rhs                       )?).chain(tenyr_insn_list!($( $tok )*)) };
 }
 
 #[test]
@@ -279,6 +349,7 @@ fn test_macro_insn_list() -> Result<(), Box<dyn std::error::Error>> {
     use Register::*;
 
     let three = 3;
+    let dest = "destination_label";
 
     let from = tenyr_insn_list! {
          B  <-  C  |~ D + 3      ;
@@ -305,6 +376,8 @@ fn test_macro_insn_list() -> Result<(), Box<dyn std::error::Error>> {
         [B] <-  (three) ^^ C + D ;
          B  -> [(three) &~ C + D];
          B  <- [(three) @  C + D];
+         B  <- @+dest   &  C + D ;
+         B  <- @+dest   &~ C + D ;
          B  <-  C  +  0x12345    ;
          B  <-  C  -  0x12345    ;
          B  <-        0x12345    ;
@@ -313,17 +386,14 @@ fn test_macro_insn_list() -> Result<(), Box<dyn std::error::Error>> {
          B  <-        (three)    ;
     };
 
-    let make =
-        |ctor : &dyn Fn(InsnGeneral) -> InstructionType, y, op, imm : i8, z, x, dd| Instruction {
-            kind : ctor(InsnGeneral {
-                y,
-                op,
-                imm : imm.into(),
-            }),
-            z,
-            x,
-            dd,
-        };
+    let make = |ctor : &dyn Fn(InsnGeneral) -> InstructionType, y, op, imm, z, x, dd| Instruction {
+        kind : ctor(InsnGeneral { y, op, imm }),
+        z,
+        x,
+        dd,
+    };
+
+    let make8 = |ctor, y, op, imm : i8, z, x, dd| make(ctor, y, op, imm.into(), z, x, dd);
 
     let make3 = |imm : i32, z, x, dd| {
         InsnResult::Ok(Instruction {
@@ -336,32 +406,37 @@ fn test_macro_insn_list() -> Result<(), Box<dyn std::error::Error>> {
 
     let from : Vec<_> = from.collect();
 
+    let imm = expr_sub_one(dest.into());
+    let im2 = imm.clone();
+
     #[rustfmt::skip]
     let to = vec![
-        make(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ),
-        make(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ),
-        make(&Type0,D,Add            , 3_i8,B,C,NoLoad    ),
-        make(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ),
-        make(&Type0,D,Multiply       ,-3_i8,B,C,NoLoad    ),
-        make(&Type0,A,BitwiseOr      , 0_i8,B,C,NoLoad    ),
-        make(&Type0,D,Add            , 0_i8,B,C,NoLoad    ),
-        make(&Type0,D,BitwiseOrn     , 0_i8,B,C,NoLoad    ),
-        make(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ),
-        make(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ),
-        make(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ),
-        make(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ),
-        make(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight),
-        make(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ),
-        make(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ),
-        make(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ),
-        make(&Type0,D,Add            , 3_i8,B,C,NoLoad    ),
-        make(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ),
-        make(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ),
-        make(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ),
-        make(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ),
-        make(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ),
-        make(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight),
-        make(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ),
+        make8(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ),
+        make8(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ),
+        make8(&Type0,D,Add            , 3_i8,B,C,NoLoad    ),
+        make8(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ),
+        make8(&Type0,D,Multiply       ,-3_i8,B,C,NoLoad    ),
+        make8(&Type0,A,BitwiseOr      , 0_i8,B,C,NoLoad    ),
+        make8(&Type0,D,Add            , 0_i8,B,C,NoLoad    ),
+        make8(&Type0,D,BitwiseOrn     , 0_i8,B,C,NoLoad    ),
+        make8(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ),
+        make8(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ),
+        make8(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ),
+        make8(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ),
+        make8(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight),
+        make8(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ),
+        make8(&Type0,D,BitwiseOrn     , 3_i8,B,C,NoLoad    ),
+        make8(&Type0,D,ShiftRightLogic, 3_i8,B,C,NoLoad    ),
+        make8(&Type0,D,Add            , 3_i8,B,C,NoLoad    ),
+        make8(&Type0,D,Multiply       , 3_i8,B,C,NoLoad    ),
+        make8(&Type1,A,Pack           , 3_i8,B,C,NoLoad    ),
+        make8(&Type2,A,Multiply       , 3_i8,B,C,NoLoad    ),
+        make8(&Type2,D,Multiply       , 3_i8,B,C,NoLoad    ),
+        make8(&Type2,D,Pack           , 3_i8,B,C,StoreLeft ),
+        make8(&Type2,D,BitwiseAndn    , 3_i8,B,C,StoreRight),
+        make8(&Type2,D,TestBit        , 3_i8,B,C,LoadRight ),
+        make (&Type2,D,BitwiseAnd     , imm ,B,C,NoLoad    ),
+        make (&Type2,D,BitwiseAndn    , im2 ,B,C,NoLoad    ),
         make3( 0x12345_i32,B,C,NoLoad)?,
         make3(-0x12345_i32,B,C,NoLoad)?,
         make3( 0x12345_i32,B,A,NoLoad)?,

--- a/tyrga-lib/src/tenyr.rs
+++ b/tyrga-lib/src/tenyr.rs
@@ -178,20 +178,10 @@ macro_rules! tenyr_rhs {
     };
     ( @+$target:ident $( $rest:tt )+ ) => {
         {
-            use $crate::exprtree::{Atom,Expr};
-            use $crate::exprtree::Operation;
             use $crate::tenyr::*;
             let base = tenyr_get_op!(tenyr_type2 $( $rest )*)?;
             if let $crate::tenyr::InstructionType::Type2(gen) = base.kind {
-                let e = Expr {
-                    a : $target.into(),
-                    op : Operation::Sub,
-                    b : Expr {
-                        a :  ".".into(),
-                        op : Operation::Add,
-                        b :  Atom::Immediate(1),
-                    }.into(),
-                }.into();
+                let e = $crate::exprtree::Expr::make_atplus_expr($target.into()).into();
                 let kind = $crate::tenyr::InstructionType::Type2($crate::tenyr::InsnGeneral {
                     imm : $crate::tenyr::Immediate::Expr(e),
                     ..gen
@@ -247,19 +237,7 @@ macro_rules! tenyr_insn {
 
 #[cfg(test)]
 fn expr_sub_one(a : exprtree::Atom) -> super::tenyr::Immediate12 {
-    Immediate12::Expr(
-        exprtree::Expr {
-            a,
-            op : exprtree::Operation::Sub,
-            b : exprtree::Expr {
-                a :  ".".into(),
-                op : exprtree::Operation::Add,
-                b :  exprtree::Atom::Immediate(1),
-            }
-            .into(),
-        }
-        .into(),
-    )
+    Immediate12::Expr(exprtree::Expr::make_atplus_expr(a).into())
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
The `@+symbol` tenyr assembly syntax sugar is convenient for readability, and has been used in this project since 4d86cbfdb32f06048f8a8749a1242bf1dc13ddf7, but heretofore only in trivial ways. The current PR expands our use of `@+` to improve the readability of generated code, while remaining tailored to the code generator's specific use cases.

Some other changes are made along the way, notably using Type3 instructions in some cases, in order to reach a larger address space.

**The emitted tenyr assembly depends on support for `@+.Llocal` references (https://github.com/kulp/tenyr/commit/6cbcab56f4c66916153c91b18b0875aa35411159), which not yet part of a published tenyr release.**