### PR TITLE
Pin cargo-tarpaulin version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,5 +40,7 @@ jobs:
         java-version: '17'
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1.3
+      with:
+        version: '0.16.0'
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
GitHub Actions are [failing](https://github.com/kulp/tyrga/actions/runs/5328933086/jobs/9705376509):
```
Run actions-rs/tarpaulin@v0.1.3
  with:
    version: latest
    out-type: Xml
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/17.0.7-7/x64
Error: Couldn't find a release tarball containing binaries for latest
```

The current PR pins the `cargo-tarpaulin` version to the (rather old) version [v0.16.0](https://crates.io/crates/cargo-tarpaulin/0.16.0) to work around this.