### PR TITLE
Migrate to anyhow::Error in tyrga-lib

### DIFF
--- a/tyrga-lib/Cargo.toml
+++ b/tyrga-lib/Cargo.toml
@@ -14,6 +14,7 @@ build = "../build.rs"
 maintenance = { status = "experimental" }
 
 [dependencies]
+anyhow = "1.0.71"
 classfile-parser = "~0.3.4"
 mangling = "0.2"
 

--- a/tyrga-lib/src/jvmtypes.rs
+++ b/tyrga-lib/src/jvmtypes.rs
@@ -1,5 +1,7 @@
 use classfile_parser::code_attribute::Instruction;
 
+use anyhow::Result;
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum JType {
     Int,
@@ -25,7 +27,7 @@ impl JType {
 }
 
 impl TryFrom<JType> for char {
-    type Error = &'static str;
+    type Error = anyhow::Error;
     #[rustfmt::skip]
     fn try_from(t : JType) -> Result<Self, Self::Error> {
         use JType::*;
@@ -38,13 +40,13 @@ impl TryFrom<JType> for char {
             Char   => Ok('C'),
             Short  => Ok('S'),
             Void   => Ok('V'),
-            Object => Err("no such mapping"),
+            Object => anyhow::bail!("no such mapping"),
         }
     }
 }
 
 impl TryFrom<char> for JType {
-    type Error = &'static str;
+    type Error = anyhow::Error;
     fn try_from(ch : char) -> Result<Self, Self::Error> {
         use JType::*;
         match ch {
@@ -58,7 +60,7 @@ impl TryFrom<char> for JType {
             'C' => Ok(Char),
             'S' => Ok(Short),
             'V' => Ok(Void),
-            _ => Err("no such mapping"),
+            _ => anyhow::bail!("no such mapping"),
         }
     }
 }

--- a/tyrga-lib/src/stack.rs
+++ b/tyrga-lib/src/stack.rs
@@ -283,7 +283,7 @@ mod test {
 
     const POINTER_UPDATE_INSNS : u16 = 1;
 
-    fn unwrap<T>(f : impl FnOnce() -> Result<T, Box<dyn std::error::Error>>) -> T {
+    fn unwrap<T>(f : impl FnOnce() -> anyhow::Result<T>) -> T {
         #[allow(clippy::unwrap_used)]
         f().unwrap()
     }


### PR DESCRIPTION
Using [`anyhow`](https://docs.rs/crate/anyhow/1.0.71) might improve quality-of-life over the hotch-potch of varying `Error` types in the current codebase.